### PR TITLE
Fix: entire app crashed on every command (missing config vars)

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-PROJECT_PATH="/data/data/com.termux/files/home/YasinPress-AI-Engine"
+PROJECT_PATH="/data/data/com.termux/files/home/YasinCoder"
 
 API_KEY=""
 
@@ -9,3 +9,13 @@ MODEL="auto"
 TEMPERATURE=0.2
 
 MAX_TOKENS=4096
+
+# Cloudflare Workers AI (used by providers/cloudflare.py).
+# Leave CF_ACCOUNT_ID / CF_API_TOKEN empty until you have a Cloudflare
+# account with Workers AI enabled; the app now falls back gracefully
+# instead of crashing on startup when these are unset.
+CF_ACCOUNT_ID=""
+
+CF_API_TOKEN=""
+
+CF_MODEL="@cf/meta/llama-3-8b-instruct"

--- a/providers/cloudflare.py
+++ b/providers/cloudflare.py
@@ -6,6 +6,10 @@ class CloudflareProvider:
 
     def chat(self,prompt):
 
+        if not CF_ACCOUNT_ID or not CF_API_TOKEN:
+
+            return "Cloudflare not configured: set CF_ACCOUNT_ID and CF_API_TOKEN in config.py"
+
         url=f"https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}/ai/run/{CF_MODEL}"
 
         data=json.dumps({

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -1,18 +1,29 @@
 from providers.cloudflare import CloudflareProvider
 from providers.local import LocalProvider
+from config import MODEL, CF_ACCOUNT_ID, CF_API_TOKEN
 
 class ProviderManager:
 
     def __init__(self):
 
         self.providers={
-
             "cloudflare":CloudflareProvider(),
-
             "local":LocalProvider()
-
         }
 
     def ask(self,prompt):
 
-        return self.providers["cloudflare"].chat(prompt)
+        provider=MODEL
+
+        if provider=="auto":
+            # auto: use Cloudflare if configured, otherwise fall back
+            # to the local provider instead of failing outright.
+            if CF_ACCOUNT_ID and CF_API_TOKEN:
+                provider="cloudflare"
+            else:
+                provider="local"
+
+        if provider not in self.providers:
+            return f"Unknown provider '{provider}' (check MODEL in config.py)"
+
+        return self.providers[provider].chat(prompt)


### PR DESCRIPTION
## مشکل
هر دستوری از YasinCoder — حتی `help` و `info` — با ImportError کرش می‌کرد چون
`providers/cloudflare.py` سه متغیر (`CF_ACCOUNT_ID`, `CF_API_TOKEN`, `CF_MODEL`)
را از `config.py` import می‌کند که هرگز تعریف نشده بودند. `test.py` هم با همین
خطا ۰ از ۶ تست پاس می‌شد.

## فیکس
- افزودن سه متغیر گمشده به config.py (خالی، امن به‌عنوان پیش‌فرض)
- guard در CloudflareProvider.chat() برای پیام واضح به‌جای کرش وقتی credential تنظیم نشده
- ProviderManager.ask() قبلاً هاردکد روی cloudflare بود؛ الان واقعاً از config.MODEL می‌خواند و در حالت auto اگر Cloudflare کانفیگ نشده باشد به local برمی‌گردد
- رفع PROJECT_PATH قدیمی (YasinPress-AI-Engine باقی‌مانده از تغییر نام)

## تأیید
`python main.py help`, `info`, `chat` بدون کرش اجرا شدند. `test.py` از ۰/۶ به ۶/۶ پاس رسید.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Workers AI support with configurable account credentials and Llama 3 model selection.
  * Added automatic provider selection based on available Cloudflare configuration.
  * Added support for explicitly selecting configured AI providers.

* **Bug Fixes**
  * Improved messaging when Cloudflare credentials are missing.
  * Added clear feedback for unknown provider selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->