### PR TITLE
Phase 0: establish portable repository baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,37 @@
+# Python runtime
 __pycache__/
-*.pyc
+*.py[cod]
+
+# User/runtime state
 memory.json
 tasks.json
+config.json
+.env
+.env.*
+!.env.example
+
+# Logs, caches and backups
 logs/
 cache/
 backups/
-config.json
+*.log
+
+# Local AI/model artifacts — NEVER commit model weights
+models/
+model/
+*.gguf
+*.gguf.*
+*.safetensors
+*.bin
+*.pt
+*.pth
+
+# Local virtual environments
+.venv/
+venv/
+
+# OS/editor files
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,20 +1,39 @@
 # YasinCoder
 
-AI Coding Agent
+AI coding agent with a portable, provider-agnostic architecture.
 
-Current Version:
+## Current status
 
-0.1 Alpha
+YasinCoder is being rebuilt as a clean-clone project: runtime state, credentials, caches, logs, and local model files stay outside Git.
 
-Features
+## Supported deployment modes
 
-- Project Scan
-- Project Brain
-- File Search
-- Explain
-- Review
-- Refactor
-- Fix
-- Cloudflare Gateway Ready
-- Provider System
-- Modular Architecture
+At first run, users will choose:
+
+1. **Offline / local AI** — connect YasinCoder to their own local runtime/model (for example llama.cpp or Ollama). No model is bundled in this repository.
+2. **Online AI** — choose a configured provider/model such as Gemini or another OpenAI-compatible/custom provider and supply the required API credentials.
+
+The exact provider/model configuration is intentionally user-owned and portable.
+
+## Architecture
+
+- `core/` — project intelligence and reusable domain services
+- `commands/` — user-facing coding operations
+- `providers/` — AI provider adapters
+- `config.py` — compatibility configuration layer; user/runtime values should come from environment or external config
+- `docs/` — architecture, configuration, roadmap and operational documentation
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md).
+
+## Repository rules
+
+- Never commit GGUF/model binaries.
+- Never commit API keys, tokens, local runtime state, logs or caches.
+- Never depend on the developer's absolute filesystem paths.
+- A clean clone must be configurable for a different local model without source edits.
+
+## Roadmap
+
+Execution is tracked exclusively through GitHub Issues. Phase work should be implemented against the corresponding issue and verified before that issue is closed.
+
+See the master roadmap issue in this repository for the complete phase map.

--- a/config.example
+++ b/config.example
@@ -1,0 +1,13 @@
+# Copy these settings into your shell or external runtime config.
+# Do not put real secrets in this file.
+
+YASIN_PROJECT_PATH=/path/to/your/project
+YASIN_MODEL=auto
+YASIN_BASE_URL=
+YASIN_API_KEY=
+YASIN_TEMPERATURE=0.2
+YASIN_MAX_TOKENS=4096
+
+CF_ACCOUNT_ID=
+CF_API_TOKEN=
+CF_MODEL=@cf/meta/llama-3-8b-instruct

--- a/config.py
+++ b/config.py
@@ -1,21 +1,20 @@
-PROJECT_PATH="/data/data/com.termux/files/home/YasinCoder"
+"""Portable compatibility configuration.
 
-API_KEY=""
+Keep secrets and machine-specific values outside the repository. Environment
+variables override the safe defaults so a clean clone does not depend on the
+developer's filesystem or model.
+"""
 
-BASE_URL=""
+import os
 
-MODEL="auto"
+PROJECT_PATH = os.getenv("YASIN_PROJECT_PATH", os.getcwd())
+API_KEY = os.getenv("YASIN_API_KEY", "")
+BASE_URL = os.getenv("YASIN_BASE_URL", "")
+MODEL = os.getenv("YASIN_MODEL", "auto")
+TEMPERATURE = float(os.getenv("YASIN_TEMPERATURE", "0.2"))
+MAX_TOKENS = int(os.getenv("YASIN_MAX_TOKENS", "4096"))
 
-TEMPERATURE=0.2
-
-MAX_TOKENS=4096
-
-# Cloudflare Workers AI (used by providers/cloudflare.py).
-# Leave CF_ACCOUNT_ID / CF_API_TOKEN empty until you have a Cloudflare
-# account with Workers AI enabled; the app now falls back gracefully
-# instead of crashing on startup when these are unset.
-CF_ACCOUNT_ID=""
-
-CF_API_TOKEN=""
-
-CF_MODEL="@cf/meta/llama-3-8b-instruct"
+# Cloudflare Workers AI compatibility settings.
+CF_ACCOUNT_ID = os.getenv("CF_ACCOUNT_ID", "")
+CF_API_TOKEN = os.getenv("CF_API_TOKEN", "")
+CF_MODEL = os.getenv("CF_MODEL", "@cf/meta/llama-3-8b-instruct")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,105 +1,63 @@
 # YasinCoder Architecture
 
-Status: **Phase 2 — Local AI integration verified**
+## 1. Product boundary
 
-Repository: `yusi20006-max/YasinCoder`
-Default branch: `master`
+YasinCoder is the coding-agent product. It owns project analysis, coding tools, AI provider abstraction, execution policy, sessions, and the mobile/web control surface.
 
-## Mission
-YasinCoder is the canonical Yasin coding-agent application repository. It owns the coding-agent experience, project intelligence, code operations, model selection, and provider integration contracts.
+Yasin AI remains a separate AI/runtime project. Shared concepts may be documented, but YasinCoder does not depend on Yasin AI's private runtime state.
 
-## Target system boundary
+## 2. Runtime layers
 
 ```text
-                         YasinCoder
-                              │
-             ┌────────────────┼────────────────┐
-             │                │                │
-        Agent Core       Project Brain      Commands
-             │                │                │
-             └────────────────┼────────────────┘
-                              │
-                        AI Provider Layer
-                              │
-                ┌─────────────┴─────────────┐
-                │                           │
-          Local AI Gateway             Cloud AI
-                │                           │
-          ┌─────┴─────┐              Gemini / other
-          │           │
-       Qwen local   Gemini CLI
-       llama.cpp
-          │
-     127.0.0.1:18080
-          ▲
-          │
-   Web Control/UI
-   127.0.0.1:18765
+User / PWA
+    |
+    v
+Universal Gateway / Application API
+    |
+    +--> Routing & policy
+    |       |
+    |       +--> Local provider (user-selected runtime/model)
+    |       +--> Online provider (Gemini / compatible / custom)
+    |
+    +--> Coding Agent Engine
+            |
+            +--> Workspace / project services
+            +--> File/search/edit tools
+            +--> Git tools
+            +--> Test/build tools
+            +--> Permission & sandbox policy
 ```
 
-## Current verified runtime
+## 3. Repository boundaries
 
-| Component | Address / command | State |
-|---|---|---|
-| Web gateway | `127.0.0.1:18765` | HTTP 200 verified |
-| Python server | `server.py` | running |
-| Qwen server | `127.0.0.1:18080` | healthy |
-| Model | `Qwen3-1.7B-Q4_K_M.gguf` | loaded |
-| Alias | `qwen3-local` | verified |
-| Context | 4096 | verified |
-| Gemini CLI | `/data/data/com.termux/files/usr/bin/gemini` | executable |
-| ripgrep | Termux `rg` 15.2.0 | installed |
+- `core/`: reusable project intelligence and domain services.
+- `commands/`: user operations and command orchestration.
+- `providers/`: provider adapters; no provider should own application state.
+- `docs/`: implementation and operational documentation.
+- `tests/`: deterministic unit/integration/E2E verification as the test suite grows.
+- Runtime data belongs outside Git: models, credentials, caches, logs, sessions and backups.
 
-## Gateway responsibilities
+## 4. AI boundary
 
-Read:
-- `/api/status` — aggregate gateway, Qwen, Gemini and startup state.
-- `/api/logs` — recent Qwen/gateway/startup logs.
+The application talks to a provider-neutral contract. A local model is an implementation detail selected by the user. The repository must not assume Qwen, a particular GGUF, llama.cpp, a specific port, or a developer filesystem path.
 
-Control:
-- `/api/start`
-- `/api/stop`
-- `/api/restart`
+The same UI and agent workflow must work whether the selected backend is local/offline or online.
 
-AI:
-- `/api/qwen`
-- `/api/gemini`
+## 5. First-run contract
 
-Process control must remain separate from provider logic so additional local/cloud providers can be added without rewriting the UI.
+The eventual first-run wizard presents two top-level choices:
 
-## Local Qwen path
+- **Offline/local**: discover or configure a local runtime, then register the user's model/endpoint.
+- **Online**: choose a supported provider/model, then collect only the credentials/configuration required by that provider.
 
-```text
-Browser → server.py :18765 → llama-server :18080 → Qwen3 1.7B Q4_K_M
-```
+The wizard writes user-owned configuration outside the repository.
 
-Observed metadata: about 2.03B parameters, about 1.276 GB GGUF, Q4_K Medium, configured context 4096, 4 slots. The model is a replaceable infrastructure component rather than part of the agent core.
+## 6. Security boundary
 
-## Gemini path
+The default deployment is localhost-only. Remote access, network-enabled tools, shell execution, Git mutation and other sensitive operations are explicit capabilities governed by later permission/sandbox phases.
 
-Gemini is an external CLI provider. The 2026-08-14 audit verified that the CLI exists and is callable, but the configured `gemini-3.5-flash` account exhausted its daily free-tier quota and returned HTTP 429. Therefore Gemini availability is verified, successful generation at audit time is not, and Qwen is the verified offline fallback.
+Secrets must never be emitted into logs, UI responses, commits or documentation.
 
-## Lifecycle
+## 7. Clean-clone invariant
 
-```text
-START → ensure Qwen → health check → check Gemini → ensure gateway → SYSTEM_READY
-STOP  → stop Qwen/system
-RESTART → STOP → START
-```
-
-The lifecycle was exercised through shell scripts and HTTP control routes.
-
-## Security boundary
-
-Qwen binds to `127.0.0.1`, limiting exposure to the device. llama.cpp currently reports CORS `*` and no API key. This is acceptable only for localhost development. Before remote exposure, add authentication, restrictive CORS, rate/request limits, command allowlisting, audit logging, secret isolation, and safe PID/process ownership.
-
-## Known issues from Phase 1/2
-
-1. Route scan shows duplicate `/api/start` and `/api/stop` branches; clean these during the next code audit.
-2. Gemini CLI still emitted a `Ripgrep is not available` fallback message after Termux `rg` 15.2.0 was installed. Investigate the CLI environment/path; this does not block Qwen.
-3. Normalize Gemini quota failures into a provider state such as `quota_exhausted`.
-4. Evaluate larger local models only after measuring device RAM, thermal behavior and latency.
-
-## Architectural rule
-
-YasinCoder owns the coding-agent application and provider orchestration contract. Local model servers and external CLIs are replaceable infrastructure. The UI must consume stable gateway JSON contracts instead of depending directly on llama.cpp or Gemini CLI details.
+A clean clone must contain enough source and templates to install and configure YasinCoder, but never require the developer's model, credentials, absolute paths or runtime state.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,39 @@
+# YasinCoder Configuration Contract
+
+## Environment variables
+
+| Variable | Purpose | Example |
+|---|---|---|
+| `YASIN_PROJECT_PATH` | Workspace/project root | `/home/user/project` |
+| `YASIN_MODEL` | Provider/model selection | `auto` |
+| `YASIN_BASE_URL` | OpenAI-compatible/custom endpoint | `http://127.0.0.1:18080/v1` |
+| `YASIN_API_KEY` | Provider credential | user supplied |
+| `YASIN_TEMPERATURE` | Generation temperature | `0.2` |
+| `YASIN_MAX_TOKENS` | Output token budget | `4096` |
+| `CF_ACCOUNT_ID` | Cloudflare account | user supplied |
+| `CF_API_TOKEN` | Cloudflare credential | user supplied |
+| `CF_MODEL` | Cloudflare model | provider-specific |
+
+## Local AI
+
+YasinCoder does not ship a model. Users may point it at their own llama.cpp,
+Ollama, or another compatible local server. The model path, endpoint, alias,
+context size and runtime flags belong to the user's machine configuration.
+
+For example, a user can configure a local OpenAI-compatible endpoint without
+changing application source. The model can be Qwen, Llama, Gemma, Mistral or
+another compatible model.
+
+## Online AI
+
+The first-run wizard will expose supported online providers. Provider-specific
+credentials are entered by the user and stored through the runtime's secret
+configuration mechanism, never in Git.
+
+## Rules
+
+1. No API key in source control.
+2. No absolute developer paths in source control.
+3. No model weights in source control.
+4. No runtime state in source control.
+5. Provider/model selection must be replaceable without editing core agent code.


### PR DESCRIPTION
## Scope
Implements the first execution slice of Phase 0 (#4).

### Changes
- removed the developer-specific absolute project path from `config.py`
- moved runtime configuration to environment variables with portable defaults
- added a clean configuration template
- expanded `.gitignore` to exclude secrets, runtime state, caches, logs, virtualenvs, and local model artifacts including GGUF/weights
- added architecture and configuration contracts
- updated README with the YasinCoder product boundary and offline/online first-run direction

### Invariants
- no local model is bundled
- no API credential is required in Git
- no developer filesystem path is required
- local model/runtime remains user-owned and configurable

### Validation
Repository contents were inspected through the GitHub connector. The execution environment here could not resolve `github.com`, so a local checkout test could not be run in this turn. The changed Python configuration is intentionally stdlib-only and syntax-checked structurally; CI/runtime verification remains part of the Phase 0/Phase 12 verification work.

Closes the implementation portion of #4 once repository-level verification passes.