### PR TITLE
Phase 1 — Generic local AI provider adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# YasinCoder portable AI configuration
+# Copy to your user-owned environment/configuration; do not commit secrets.
+
+# Provider selection: cloudflare | local
+YASIN_AI_PROVIDER=local
+
+# Local runtime: openai (llama.cpp/OpenAI-compatible) | ollama
+YASIN_LOCAL_RUNTIME=openai
+YASIN_LOCAL_BASE_URL=http://127.0.0.1:18080
+YASIN_LOCAL_MODEL=your-model-name
+YASIN_LOCAL_TIMEOUT=120
+
+# Optional generic settings
+YASIN_PROJECT_PATH=/path/to/your/project
+YASIN_MODEL=auto
+YASIN_TEMPERATURE=0.2
+YASIN_MAX_TOKENS=4096
+
+# Cloud provider credentials are user-owned and optional.
+# CLOUDFLARE_API_TOKEN=
+# CLOUDFLARE_ACCOUNT_ID=
+# CLOUDFLARE_MODEL=@cf/meta/llama-3.1-8b-instruct

--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
 # YasinCoder
 
-AI Coding Agent
+Portable, provider-agnostic AI coding agent.
 
-Current Version:
+## Current status
 
-0.1 Alpha
+Version: 0.1 Alpha
 
-Features
+### AI provider architecture
+
+YasinCoder separates the coding-agent layer from the AI runtime. A clone does **not** require the developer's model, device paths, or local runtime.
+
+Supported provider families:
+
+- **Local** — OpenAI-compatible local servers such as llama.cpp and other compatible runtimes.
+- **Ollama** — supported through the same local-provider contract.
+- **Cloudflare** — existing remote provider support.
+
+The local model name, endpoint, runtime and timeout are user configuration. No GGUF/model binary is bundled or committed.
+
+Example environment variables:
+
+```text
+YASIN_AI_PROVIDER=local
+YASIN_LOCAL_RUNTIME=openai
+YASIN_LOCAL_BASE_URL=http://127.0.0.1:18080
+YASIN_LOCAL_MODEL=your-model-name
+```
+
+Copy `.env.example` as a reference and keep secrets/runtime state outside Git.
+
+## Features
 
 - Project Scan
 - Project Brain
@@ -15,6 +38,21 @@ Features
 - Review
 - Refactor
 - Fix
-- Cloudflare Gateway Ready
-- Provider System
-- Modular Architecture
+- Provider system
+- Generic local AI adapter
+- Cloudflare gateway
+- Modular architecture
+
+## Local model portability
+
+For llama.cpp, point `YASIN_LOCAL_BASE_URL` at its OpenAI-compatible `/v1` API and set `YASIN_LOCAL_MODEL` to the alias exposed by that server. The model file itself remains outside the repository and can be any compatible model selected by the user.
+
+For Ollama, set `YASIN_LOCAL_RUNTIME=ollama`, point `YASIN_LOCAL_BASE_URL` at the Ollama server, and set `YASIN_LOCAL_MODEL` to the installed model name.
+
+## Tests
+
+Run:
+
+```bash
+python -m unittest discover -s tests -v
+```

--- a/config.py
+++ b/config.py
@@ -1,29 +1,33 @@
-PROJECT_PATH="/data/data/com.termux/files/home/YasinPress-AI-Engine"
+"""Portable configuration defaults.
 
-API_KEY=""
+Secrets and machine-specific settings should come from the environment or
+user-owned runtime configuration, never from the repository.
+"""
 
-BASE_URL=""
-
-MODEL="auto"
-
-TEMPERATURE=0.2
-
-MAX_TOKENS=4096
-
+import os
 from pathlib import Path
 
-BASE_DIR = Path(__file__).parent
+PROJECT_PATH = os.getenv("YASIN_PROJECT_PATH", str(Path.cwd()))
+API_KEY = os.getenv("YASIN_API_KEY", "")
+BASE_URL = os.getenv("YASIN_BASE_URL", "")
+MODEL = os.getenv("YASIN_MODEL", "auto")
+TEMPERATURE = float(os.getenv("YASIN_TEMPERATURE", "0.2"))
+MAX_TOKENS = int(os.getenv("YASIN_MAX_TOKENS", "4096"))
 
-CF_TOKEN_FILE = BASE_DIR / "cf_token.txt"
-CF_ACCOUNT_FILE = BASE_DIR / "cf_account.txt"
+# Cloudflare remains supported as an existing remote provider, but credentials
+# are user-owned. Files are resolved from the optional YASIN_CONFIG_DIR.
+CONFIG_DIR = Path(os.getenv("YASIN_CONFIG_DIR", Path.home() / ".yasin-coder"))
+CF_TOKEN_FILE = CONFIG_DIR / "cf_token.txt"
+CF_ACCOUNT_FILE = CONFIG_DIR / "cf_account.txt"
+
 
 def load_secret(path):
-    if path.exists():
+    try:
         return path.read_text(encoding="utf-8").strip()
-    return ""
+    except (FileNotFoundError, OSError):
+        return ""
 
-CF_TOKEN = load_secret(CF_TOKEN_FILE)
-CF_ACCOUNT_ID = load_secret(CF_ACCOUNT_FILE)
 
-CF_MODEL = "@cf/meta/llama-3.1-8b-instruct"
-
+CF_TOKEN = os.getenv("CLOUDFLARE_API_TOKEN", load_secret(CF_TOKEN_FILE))
+CF_ACCOUNT_ID = os.getenv("CLOUDFLARE_ACCOUNT_ID", load_secret(CF_ACCOUNT_FILE))
+CF_MODEL = os.getenv("CLOUDFLARE_MODEL", "@cf/meta/llama-3.1-8b-instruct")

--- a/providers/base.py
+++ b/providers/base.py
@@ -1,7 +1,17 @@
-class BaseProvider:
+from abc import ABC, abstractmethod
 
-    name="base"
 
-    def chat(self,prompt):
+class BaseProvider(ABC):
+    """Provider contract shared by local and remote AI backends."""
 
+    name = "base"
+
+    @abstractmethod
+    def chat(self, prompt: str) -> str:
         raise NotImplementedError
+
+    def health(self) -> bool:
+        return True
+
+    def capabilities(self) -> dict:
+        return {"chat": True, "streaming": False}

--- a/providers/local.py
+++ b/providers/local.py
@@ -22,12 +22,7 @@ class LocalProvider(BaseProvider):
         self.timeout = float(timeout or os.getenv("YASIN_LOCAL_TIMEOUT", "120"))
 
     def capabilities(self):
-        return {
-            "chat": True,
-            "streaming": False,
-            "runtime": self.runtime,
-            "model": self.model,
-        }
+        return {"chat": True, "streaming": False, "runtime": self.runtime, "model": self.model}
 
     def _request(self, path, payload=None):
         url = self.base_url + path
@@ -52,7 +47,7 @@ class LocalProvider(BaseProvider):
             if self.runtime == "ollama":
                 self._request("/api/tags")
             else:
-                self._request("/models")
+                self._request("/v1/models")
             return True
         except Exception:
             return False
@@ -68,7 +63,6 @@ class LocalProvider(BaseProvider):
             )
             return str(result.get("message", {}).get("content", ""))
 
-        # OpenAI-compatible contract used by llama.cpp and other local servers.
         endpoint = "/v1/chat/completions" if not self.base_url.endswith("/v1") else "/chat/completions"
         result = self._request(
             endpoint,

--- a/providers/local.py
+++ b/providers/local.py
@@ -1,9 +1,80 @@
+"""Generic local AI provider.
+
+Supports OpenAI-compatible local servers (llama.cpp and similar) and Ollama.
+All runtime/model details are user configuration; no model is bundled here.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.request
+
 from providers.base import BaseProvider
 
+
 class LocalProvider(BaseProvider):
+    name = "local"
 
-    name="local"
+    def __init__(self, runtime=None, base_url=None, model=None, timeout=None):
+        self.runtime = (runtime or os.getenv("YASIN_LOCAL_RUNTIME", "openai")).lower()
+        self.base_url = (base_url or os.getenv("YASIN_LOCAL_BASE_URL", "http://127.0.0.1:11434")).rstrip("/")
+        self.model = model or os.getenv("YASIN_LOCAL_MODEL", "local-model")
+        self.timeout = float(timeout or os.getenv("YASIN_LOCAL_TIMEOUT", "120"))
 
-    def chat(self,prompt):
+    def capabilities(self):
+        return {
+            "chat": True,
+            "streaming": False,
+            "runtime": self.runtime,
+            "model": self.model,
+        }
 
-        return "Local model is not configured yet."
+    def _request(self, path, payload=None):
+        url = self.base_url + path
+        data = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST" if payload is not None else "GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Local provider HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Local provider unavailable: {exc.reason}") from exc
+
+    def health(self) -> bool:
+        try:
+            if self.runtime == "ollama":
+                self._request("/api/tags")
+            else:
+                self._request("/models")
+            return True
+        except Exception:
+            return False
+
+    def chat(self, prompt: str) -> str:
+        if not prompt or not isinstance(prompt, str):
+            raise ValueError("prompt must be a non-empty string")
+
+        if self.runtime == "ollama":
+            result = self._request(
+                "/api/chat",
+                {"model": self.model, "messages": [{"role": "user", "content": prompt}], "stream": False},
+            )
+            return str(result.get("message", {}).get("content", ""))
+
+        # OpenAI-compatible contract used by llama.cpp and other local servers.
+        endpoint = "/v1/chat/completions" if not self.base_url.endswith("/v1") else "/chat/completions"
+        result = self._request(
+            endpoint,
+            {"model": self.model, "messages": [{"role": "user", "content": prompt}]},
+        )
+        try:
+            return str(result["choices"][0]["message"]["content"])
+        except (KeyError, IndexError, TypeError) as exc:
+            raise RuntimeError(f"Invalid local provider response: {result}") from exc

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -1,18 +1,33 @@
+import os
+
 from providers.cloudflare import CloudflareProvider
 from providers.local import LocalProvider
 
+
 class ProviderManager:
+    """Registry and selector for configured AI providers."""
 
-    def __init__(self):
-
-        self.providers={
-
-            "cloudflare":CloudflareProvider(),
-
-            "local":LocalProvider()
-
+    def __init__(self, default=None):
+        self.providers = {
+            "cloudflare": CloudflareProvider(),
+            "local": LocalProvider(),
         }
+        self.default = default or os.getenv("YASIN_AI_PROVIDER", "cloudflare")
+        if self.default not in self.providers:
+            raise ValueError(f"Unsupported AI provider: {self.default}")
 
-    def ask(self,prompt):
+    def get(self, name=None):
+        provider_name = name or self.default
+        try:
+            return self.providers[provider_name]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported AI provider: {provider_name}") from exc
 
-        return self.providers["cloudflare"].chat(prompt)
+    def ask(self, prompt, provider=None):
+        return self.get(provider).chat(prompt)
+
+    def health(self, provider=None):
+        return self.get(provider).health()
+
+    def capabilities(self, provider=None):
+        return self.get(provider).capabilities()

--- a/tests/test_local_provider.py
+++ b/tests/test_local_provider.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch
+
+from providers.local import LocalProvider
+from providers.manager import ProviderManager
+
+
+class LocalProviderTests(unittest.TestCase):
+    def test_openai_compatible_chat_contract(self):
+        provider = LocalProvider(runtime="openai", base_url="http://127.0.0.1:18080", model="test-model")
+        with patch.object(provider, "_request", return_value={"choices": [{"message": {"content": "OK"}}]}) as request:
+            self.assertEqual(provider.chat("hello"), "OK")
+            request.assert_called_once_with(
+                "/v1/chat/completions",
+                {"model": "test-model", "messages": [{"role": "user", "content": "hello"}]},
+            )
+
+    def test_ollama_chat_contract(self):
+        provider = LocalProvider(runtime="ollama", base_url="http://127.0.0.1:11434", model="test-model")
+        with patch.object(provider, "_request", return_value={"message": {"content": "OK"}}) as request:
+            self.assertEqual(provider.chat("hello"), "OK")
+            request.assert_called_once_with(
+                "/api/chat",
+                {"model": "test-model", "messages": [{"role": "user", "content": "hello"}], "stream": False},
+            )
+
+    def test_invalid_prompt_is_rejected(self):
+        provider = LocalProvider()
+        with self.assertRaises(ValueError):
+            provider.chat("")
+
+    def test_manager_selects_local_provider_from_environment(self):
+        with patch.dict("os.environ", {"YASIN_AI_PROVIDER": "local"}):
+            manager = ProviderManager()
+            self.assertEqual(manager.default, "local")
+            self.assertEqual(manager.get().name, "local")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #5.

Implements a generic local provider contract with configurable llama.cpp/OpenAI-compatible and Ollama runtimes, portable environment-based model configuration, provider selection, README guidance, and deterministic provider contract tests. No local model binary or developer device path is included.