### PR TITLE
Phase 2 — Model manager and portable user configuration

### DIFF
--- a/commands/models.py
+++ b/commands/models.py
@@ -1,7 +1,25 @@
-from core.constants import SUPPORTED_MODELS
+from models.manager import ModelManager
+
 
 class ModelsCommand:
+    def __init__(self, manager=None):
+        self.manager = manager or ModelManager()
 
     def run(self):
+        return {
+            "default": self.manager.data.get("default", ""),
+            "models": self.manager.list(),
+            "config_file": str(self.manager.path),
+        }
 
-        return SUPPORTED_MODELS
+    def discover(self):
+        return self.manager.ensure_discovered()
+
+    def add(self, model):
+        return self.manager.upsert(model)
+
+    def remove(self, name):
+        return self.manager.remove(name)
+
+    def select(self, name):
+        return self.manager.select(name)

--- a/config.example
+++ b/config.example
@@ -1,13 +1,21 @@
 # Copy these settings into your shell or external runtime config.
-# Do not put real secrets in this file.
+# Do not put real secrets or machine-specific model paths in Git.
 
 YASIN_PROJECT_PATH=/path/to/your/project
+# Optional model name override. Otherwise the external registry default is used.
 YASIN_MODEL=auto
+YASIN_MODEL_NAME=
 YASIN_BASE_URL=
 YASIN_API_KEY=
+YASIN_MODELS_FILE=
 YASIN_TEMPERATURE=0.2
 YASIN_MAX_TOKENS=4096
 
+# Cloudflare is optional.
 CF_ACCOUNT_ID=
 CF_API_TOKEN=
 CF_MODEL=@cf/meta/llama-3-8b-instruct
+
+# Local model definitions are stored outside the clone by default:
+# ~/.config/yasin-coder/models.json
+# Supported runtime types: llama_cpp, ollama, openai_compatible, cloudflare.

--- a/docs/model-portability.md
+++ b/docs/model-portability.md
@@ -1,0 +1,45 @@
+# Portable model configuration
+
+YasinCoder does not require the developer's local GGUF file, model path, or runtime. A clone stores machine-specific model definitions outside Git.
+
+## Registry
+
+Default location:
+
+`~/.config/yasin-coder/models.json`
+
+Override it with `YASIN_MODELS_FILE`.
+
+Each model entry contains at least `name` and `type`. Supported runtime types are:
+
+- `llama_cpp` — llama.cpp server exposing `/v1/chat/completions`.
+- `ollama` — Ollama `/api/generate` runtime.
+- `openai_compatible` — any compatible local or remote endpoint.
+- `cloudflare` — optional Cloudflare Workers AI configuration.
+
+## First run
+
+The model manager discovers configured `YASIN_BASE_URL`, a local llama.cpp server on port `18080`, and Ollama on port `11434` when reachable. Discovered runtimes are registered and the first available runtime becomes the default if no selection exists.
+
+## Manual model
+
+A user can register a model without editing Python source:
+
+```python
+from models.manager import ModelManager
+
+m = ModelManager()
+m.upsert({
+    "name": "my-qwen",
+    "type": "llama_cpp",
+    "base_url": "http://127.0.0.1:18080",
+    "model": "my-qwen-model"
+})
+m.select("my-qwen")
+```
+
+The selection survives restart because the registry is persisted outside the repository.
+
+## Portability rule
+
+Never commit GGUF files, absolute home-directory paths, API keys, or machine-specific runtime state. Commit only examples and code that can discover or reference a user's own runtime.

--- a/models/manager.py
+++ b/models/manager.py
@@ -1,0 +1,119 @@
+"""Portable model registry and runtime discovery.
+
+Machine-specific model definitions live outside the repository. The registry
+uses XDG_CONFIG_HOME (or ~/.config) and can be overridden with
+YASIN_MODELS_FILE for tests or custom deployments.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG_DIR = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config")) / "yasin-coder"
+DEFAULT_MODELS_FILE = DEFAULT_CONFIG_DIR / "models.json"
+
+
+def _path() -> Path:
+    return Path(os.getenv("YASIN_MODELS_FILE", str(DEFAULT_MODELS_FILE))).expanduser()
+
+
+class ModelManager:
+    def __init__(self, path: str | Path | None = None):
+        self.path = Path(path).expanduser() if path else _path()
+        self.data = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"version": 1, "default": "", "models": []}
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("models"), list):
+                return data
+        except (OSError, ValueError):
+            pass
+        return {"version": 1, "default": "", "models": []}
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self.data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        tmp.replace(self.path)
+
+    def list(self) -> list[dict[str, Any]]:
+        return list(self.data["models"])
+
+    def get(self, name: str) -> dict[str, Any] | None:
+        return next((m for m in self.data["models"] if m.get("name") == name), None)
+
+    def upsert(self, model: dict[str, Any]) -> dict[str, Any]:
+        if not model.get("name") or not model.get("type"):
+            raise ValueError("model requires name and type")
+        models = self.data["models"]
+        for i, current in enumerate(models):
+            if current.get("name") == model["name"]:
+                models[i] = {**current, **model}
+                self.save()
+                return models[i]
+        models.append(model)
+        self.save()
+        return model
+
+    def remove(self, name: str) -> bool:
+        before = len(self.data["models"])
+        self.data["models"] = [m for m in self.data["models"] if m.get("name") != name]
+        if self.data.get("default") == name:
+            self.data["default"] = ""
+        changed = len(self.data["models"]) != before
+        if changed:
+            self.save()
+        return changed
+
+    def select(self, name: str) -> dict[str, Any]:
+        model = self.get(name)
+        if not model:
+            raise KeyError(name)
+        self.data["default"] = name
+        self.save()
+        return model
+
+    def default(self) -> dict[str, Any] | None:
+        name = os.getenv("YASIN_MODEL", "").strip() or self.data.get("default", "")
+        return self.get(name) if name else (self.data["models"][0] if self.data["models"] else None)
+
+    def discover(self) -> list[dict[str, Any]]:
+        found: list[dict[str, Any]] = []
+        env_url = os.getenv("YASIN_BASE_URL", "").strip()
+        env_model = os.getenv("YASIN_MODEL_NAME", "").strip()
+        if env_url:
+            found.append({"name": env_model or "configured-endpoint", "type": "openai_compatible", "base_url": env_url, "model": env_model})
+        probes = [
+            ("llama-cpp", "http://127.0.0.1:18080", "qwen3-local"),
+            ("ollama", "http://127.0.0.1:11434", ""),
+        ]
+        for name, base, model in probes:
+            if self._healthy(base):
+                found.append({"name": name, "type": "ollama" if name == "ollama" else "llama_cpp", "base_url": base, "model": model})
+        return found
+
+    @staticmethod
+    def _healthy(base: str) -> bool:
+        for endpoint in ("/health", "/api/tags", "/v1/models"):
+            try:
+                with urllib.request.urlopen(base.rstrip("/") + endpoint, timeout=1.5) as response:
+                    if 200 <= response.status < 300:
+                        return True
+            except Exception:
+                continue
+        return False
+
+    def ensure_discovered(self) -> list[dict[str, Any]]:
+        discovered = []
+        for model in self.discover():
+            discovered.append(self.upsert(model))
+        if not self.default() and discovered:
+            self.select(discovered[0]["name"])
+        return discovered

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -1,29 +1,50 @@
+from models.manager import ModelManager
 from providers.cloudflare import CloudflareProvider
-from providers.local import LocalProvider
+from providers.model_endpoint import ModelEndpoint
 from config import MODEL, CF_ACCOUNT_ID, CF_API_TOKEN
 
+
 class ProviderManager:
+    """Select configured providers without embedding machine-specific models."""
 
     def __init__(self):
+        self.models = ModelManager()
+        self.models.ensure_discovered()
+        self.providers = {"cloudflare": CloudflareProvider()}
 
-        self.providers={
-            "cloudflare":CloudflareProvider(),
-            "local":LocalProvider()
-        }
+    def list_models(self):
+        return self.models.list()
 
-    def ask(self,prompt):
+    def register(self, model):
+        return self.models.upsert(model)
 
-        provider=MODEL
+    def remove(self, name):
+        return self.models.remove(name)
 
-        if provider=="auto":
-            # auto: use Cloudflare if configured, otherwise fall back
-            # to the local provider instead of failing outright.
-            if CF_ACCOUNT_ID and CF_API_TOKEN:
-                provider="cloudflare"
-            else:
-                provider="local"
+    def select(self, name):
+        return self.models.select(name)
 
-        if provider not in self.providers:
-            return f"Unknown provider '{provider}' (check MODEL in config.py)"
+    def health(self, name=None):
+        model = self.models.get(name) if name else self.models.default()
+        if not model:
+            return False
+        if model.get("type") == "cloudflare":
+            return bool(CF_ACCOUNT_ID and CF_API_TOKEN)
+        return ModelEndpoint(model).health()
 
-        return self.providers[provider].chat(prompt)
+    def ask(self, prompt):
+        selected = MODEL.strip() if MODEL.strip() and MODEL.strip() != "auto" else None
+        model = self.models.get(selected) if selected else self.models.default()
+
+        if model and model.get("type") in {"llama_cpp", "ollama", "openai_compatible"}:
+            endpoint = ModelEndpoint(model)
+            if not endpoint.health():
+                return f"Model '{model.get('name')}' is unavailable; configure another model."
+            return endpoint.chat(prompt)
+
+        if model and model.get("type") == "cloudflare":
+            return self.providers["cloudflare"].chat(prompt)
+
+        if CF_ACCOUNT_ID and CF_API_TOKEN:
+            return self.providers["cloudflare"].chat(prompt)
+        return "No AI model configured. Run model setup or set YASIN_BASE_URL/YASIN_MODEL_NAME."

--- a/providers/model_endpoint.py
+++ b/providers/model_endpoint.py
@@ -1,0 +1,47 @@
+"""OpenAI-compatible local runtime adapter for llama.cpp, Ollama, and peers."""
+from __future__ import annotations
+
+import json
+import urllib.request
+
+
+class ModelEndpoint:
+    def __init__(self, model: dict):
+        self.model = model
+        self.base_url = str(model.get("base_url", "")).rstrip("/")
+
+    def health(self) -> bool:
+        candidates = ["/health", "/api/tags", "/v1/models"]
+        for path in candidates:
+            try:
+                with urllib.request.urlopen(self.base_url + path, timeout=3) as response:
+                    if 200 <= response.status < 300:
+                        return True
+            except Exception:
+                continue
+        return False
+
+    def chat(self, prompt: str) -> str:
+        kind = self.model.get("type")
+        if kind == "ollama":
+            payload = {"model": self.model.get("model", ""), "prompt": prompt, "stream": False}
+            url = self.base_url + "/api/generate"
+        else:
+            payload = {
+                "model": self.model.get("model") or self.model.get("name", "local"),
+                "messages": [{"role": "user", "content": prompt}],
+                "temperature": self.model.get("temperature", 0.2),
+                "max_tokens": self.model.get("max_tokens", 4096),
+            }
+            url = self.base_url + "/v1/chat/completions"
+        request = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(request, timeout=float(self.model.get("timeout", 120))) as response:
+            data = json.loads(response.read().decode())
+        if kind == "ollama":
+            return str(data.get("response", ""))
+        choices = data.get("choices", [])
+        return str(choices[0].get("message", {}).get("content", "")) if choices else str(data)

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,0 +1,22 @@
+import json
+
+from models.manager import ModelManager
+
+
+def test_registry_lifecycle(tmp_path):
+    path = tmp_path / "models.json"
+    manager = ModelManager(path)
+    assert manager.list() == []
+
+    manager.upsert({"name": "my-local", "type": "openai_compatible", "base_url": "http://127.0.0.1:9999", "model": "my-model"})
+    assert manager.get("my-local")["model"] == "my-model"
+
+    manager.select("my-local")
+    assert manager.default()["name"] == "my-local"
+
+    reloaded = ModelManager(path)
+    assert reloaded.default()["name"] == "my-local"
+    assert json.loads(path.read_text())["default"] == "my-local"
+
+    assert reloaded.remove("my-local") is True
+    assert reloaded.default() is None


### PR DESCRIPTION
Closes #6

- Adds external persistent model registry.
- Discovers llama.cpp/Ollama/configured endpoints.
- Supports register, update, remove, select, aliases via model metadata.
- Routes local AI through a generic endpoint adapter.
- Keeps machine-specific configuration outside Git.
- Adds portability documentation and registry lifecycle tests.