### PR TITLE
Phase 3 — Universal AI gateway API

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -1,0 +1,35 @@
+# YasinCoder Universal AI Gateway
+
+YasinCoder exposes a provider-neutral HTTP contract so the UI and agent do not need to know whether the selected backend is local or cloud.
+
+## Endpoints
+
+- `GET /health` — service health.
+- `GET /v1/models` — configured models with provider and capability metadata.
+- `POST /v1/chat/completions` — OpenAI-compatible chat request/response shape.
+- `GET /api/status` — compatibility health route.
+- `GET /api/models` — compatibility model listing.
+- `POST /api/chat` — compatibility chat route.
+
+## Request
+
+```json
+{
+  "model": "my-model",
+  "messages": [
+    {"role": "user", "content": "Hello"}
+  ]
+}
+```
+
+The model is optional when the configured default should be used. Unknown explicit models return a normalized `model_not_found` error.
+
+## Runtime configuration
+
+No model weights, API keys, or device-specific paths belong in Git. `ProviderManager` resolves the user's configured local runtime (for example llama.cpp or Ollama) or cloud provider.
+
+The gateway binds to localhost by default. Remote exposure and authentication belong to the security phase.
+
+## Compatibility
+
+The legacy `/api/*` routes are intentionally thin compatibility aliases. New clients should use `/v1/*` so the provider implementation can change without changing the client contract.

--- a/gateway.py
+++ b/gateway.py
@@ -1,0 +1,142 @@
+"""Provider-neutral HTTP gateway for YasinCoder.
+
+The gateway exposes one stable contract for configured AI backends. Runtime/model
+configuration remains outside Git and is resolved by ProviderManager.
+"""
+from __future__ import annotations
+
+import json
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from providers.manager import ProviderManager
+
+
+class GatewayError(Exception):
+    def __init__(self, code: str, message: str, status: int = 400):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status = status
+
+
+class Gateway:
+    def __init__(self, manager: ProviderManager | None = None):
+        self.manager = manager or ProviderManager()
+
+    def models(self) -> list[dict[str, Any]]:
+        result = []
+        for model in self.manager.list_models():
+            result.append({
+                "id": model.get("name") or model.get("model"),
+                "name": model.get("name") or model.get("model"),
+                "provider": model.get("type", "unknown"),
+                "capabilities": model.get("capabilities", ["chat"]),
+                "default": model.get("default", False),
+            })
+        return result
+
+    def chat(self, payload: dict[str, Any]) -> dict[str, Any]:
+        messages = payload.get("messages")
+        if not isinstance(messages, list) or not messages:
+            raise GatewayError("invalid_request", "messages must be a non-empty list")
+
+        text_parts = []
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content", "")
+            if isinstance(content, str) and content:
+                text_parts.append(content)
+        if not text_parts:
+            raise GatewayError("invalid_request", "messages contain no text content")
+
+        prompt = "\n".join(text_parts)
+        requested = payload.get("model")
+        model = self.manager.models.get(requested) if requested else self.manager.models.default()
+        if requested and not model:
+            raise GatewayError("model_not_found", f"Model '{requested}' is not configured", 404)
+
+        try:
+            output = self.manager.ask(prompt)
+        except Exception as exc:
+            raise GatewayError("provider_error", str(exc), 502) from exc
+
+        model_name = (model or {}).get("name") or (model or {}).get("model") or requested or "auto"
+        return {
+            "id": f"yasin-{int(time.time() * 1000)}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model_name,
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": str(output)},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        }
+
+
+class Handler(BaseHTTPRequestHandler):
+    gateway: Gateway | None = None
+    server_version = "YasinCoderGateway/1.0"
+
+    def _send(self, status: int, data: dict[str, Any]) -> None:
+        body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path in ("/health", "/api/status"):
+            self._send(200, {"ok": True, "service": "yasin-coder-gateway"})
+            return
+        if self.path in ("/v1/models", "/api/models"):
+            try:
+                models = self.gateway.models()  # type: ignore[union-attr]
+                self._send(200, {"object": "list", "data": models})
+            except Exception as exc:
+                self._send(500, {"error": {"code": "internal_error", "message": str(exc)}})
+            return
+        self._send(404, {"error": {"code": "not_found", "message": "Route not found"}})
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        try:
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except (ValueError, json.JSONDecodeError):
+            self._send(400, {"error": {"code": "invalid_json", "message": "Request body must be JSON"}})
+            return
+
+        if self.path in ("/v1/chat/completions", "/api/chat"):
+            try:
+                result = self.gateway.chat(payload)  # type: ignore[union-attr]
+                self._send(200, result)
+            except GatewayError as exc:
+                self._send(exc.status, {"error": {"code": exc.code, "message": exc.message}})
+            except Exception as exc:
+                self._send(500, {"error": {"code": "internal_error", "message": str(exc)}})
+            return
+        self._send(404, {"error": {"code": "not_found", "message": "Route not found"}})
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+def create_server(host: str = "127.0.0.1", port: int = 18765, manager: ProviderManager | None = None):
+    Handler.gateway = Gateway(manager)
+    return ThreadingHTTPServer((host, port), Handler)
+
+
+def main() -> None:
+    server = create_server()
+    print(f"YasinCoder gateway listening on http://{server.server_address[0]}:{server.server_address[1]}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,84 @@
+import json
+import unittest
+from urllib.request import Request, urlopen
+from threading import Thread
+
+from gateway import create_server
+
+
+class FakeModels:
+    def list(self):
+        return [{"name": "fake-local", "type": "openai_compatible", "capabilities": ["chat"], "default": True}]
+
+    def get(self, name):
+        return self.list()[0] if name == "fake-local" else None
+
+    def default(self):
+        return self.list()[0]
+
+
+class FakeManager:
+    def __init__(self):
+        self.models = FakeModels()
+
+    def list_models(self):
+        return self.models.list()
+
+    def ask(self, prompt):
+        return f"reply:{prompt}"
+
+
+class GatewayContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = create_server("127.0.0.1", 0, FakeManager())
+        cls.thread = Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.base = f"http://127.0.0.1:{cls.server.server_address[1]}"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def test_health(self):
+        with urlopen(self.base + "/health") as response:
+            self.assertEqual(response.status, 200)
+            self.assertTrue(json.load(response)["ok"])
+
+    def test_models(self):
+        with urlopen(self.base + "/v1/models") as response:
+            data = json.load(response)
+            self.assertEqual(data["data"][0]["id"], "fake-local")
+            self.assertEqual(data["data"][0]["provider"], "openai_compatible")
+
+    def test_chat_completions(self):
+        request = Request(
+            self.base + "/v1/chat/completions",
+            data=json.dumps({
+                "model": "fake-local",
+                "messages": [{"role": "user", "content": "hello"}],
+            }).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urlopen(request) as response:
+            data = json.load(response)
+            self.assertEqual(data["object"], "chat.completion")
+            self.assertEqual(data["model"], "fake-local")
+            self.assertEqual(data["choices"][0]["message"]["content"], "reply:hello")
+
+    def test_unknown_model(self):
+        request = Request(
+            self.base + "/v1/chat/completions",
+            data=json.dumps({
+                "model": "missing",
+                "messages": [{"role": "user", "content": "hello"}],
+            }).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with self.assertRaises(Exception):
+            urlopen(request)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Unify local and cloud AI behind a provider-neutral gateway.

Tasks:
- Standard chat/completion endpoint.
- Provider/model listing endpoint.
- Health/status endpoint.
- Normalize request/response/error formats.
- Streaming support where backend allows it.
- Provider capability metadata.
- Timeouts and cancellation.
- Backward compatibility for current /api/qwen and /api/gemini during migration.

Acceptance:
- UI talks to one gateway contract.
- Backend provider can change without UI changes.