### PR TITLE
Phase 4: deterministic routing, fallback, and offline-first policy

### DIFF
--- a/config.example
+++ b/config.example
@@ -11,6 +11,19 @@ YASIN_MODELS_FILE=
 YASIN_TEMPERATURE=0.2
 YASIN_MAX_TOKENS=4096
 
+# Routing policy is stored with the external model definition, not in Git.
+# Example models.json entry:
+# {
+#   "name": "local",
+#   "type": "llama_cpp",
+#   "base_url": "http://127.0.0.1:18080",
+#   "model": "my-local-model",
+#   "offline": true,
+#   "fallbacks": []
+# }
+# For online mode, set ordered fallback names, e.g. ["local", "cloud"]
+# Offline mode ignores all fallbacks and never contacts a cloud provider.
+
 # Cloudflare is optional.
 CF_ACCOUNT_ID=
 CF_API_TOKEN=

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -4,11 +4,12 @@ YasinCoder exposes a provider-neutral HTTP contract so the UI and agent do not n
 
 ## Endpoints
 
-- `GET /health` — service health.
+- `GET /health` — service health and current routing state.
 - `GET /v1/models` — configured models with provider and capability metadata.
 - `POST /v1/chat/completions` — OpenAI-compatible chat request/response shape.
 - `GET /api/status` — compatibility health route.
 - `GET /api/models` — compatibility model listing.
+- `GET /api/routing` — last routing decision and sanitized attempt outcomes.
 - `POST /api/chat` — compatibility chat route.
 
 ## Request
@@ -23,6 +24,16 @@ YasinCoder exposes a provider-neutral HTTP contract so the UI and agent do not n
 ```
 
 The model is optional when the configured default should be used. Unknown explicit models return a normalized `model_not_found` error.
+
+## Routing and fallback
+
+Each external model definition may contain an ordered `fallbacks` list. The router de-duplicates names and never follows fallback references recursively, preventing loops.
+
+Only transient `timeout`, `network`, and server failures advance to the next fallback. Authentication failures, quota/rate-limit responses, missing models, invalid configuration, and other non-transient failures stop immediately. This prevents quota exhaustion from becoming an infinite retry loop.
+
+When `offline: true` is set on the selected model, the chain contains only that model. Cloud providers are never contacted in offline mode.
+
+Routing decisions are exposed through `/api/routing` and the `routing` field of successful chat responses. Logs contain only provider names and sanitized failure classes; credentials and raw provider payloads are not emitted by the router.
 
 ## Runtime configuration
 

--- a/gateway.py
+++ b/gateway.py
@@ -11,6 +11,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
 from providers.manager import ProviderManager
+from routing import RoutingError
 
 
 class GatewayError(Exception):
@@ -37,6 +38,9 @@ class Gateway:
             })
         return result
 
+    def routing(self) -> dict[str, Any]:
+        return self.manager.routing()
+
     def chat(self, payload: dict[str, Any]) -> dict[str, Any]:
         messages = payload.get("messages")
         if not isinstance(messages, list) or not messages:
@@ -59,9 +63,12 @@ class Gateway:
             raise GatewayError("model_not_found", f"Model '{requested}' is not configured", 404)
 
         try:
-            output = self.manager.ask(prompt)
+            output = self.manager.ask(prompt, model_name=requested)
+        except RoutingError as exc:
+            status = 401 if exc.kind == "auth" else 429 if exc.kind == "quota" else 503 if exc.kind in {"timeout", "network", "server"} else 502
+            raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", status) from exc
         except Exception as exc:
-            raise GatewayError("provider_error", str(exc), 502) from exc
+            raise GatewayError("provider_error", "Configured provider failed", 502) from exc
 
         model_name = (model or {}).get("name") or (model or {}).get("model") or requested or "auto"
         return {
@@ -75,6 +82,7 @@ class Gateway:
                 "finish_reason": "stop",
             }],
             "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "routing": self.routing(),
         }
 
 
@@ -93,14 +101,17 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if self.path in ("/health", "/api/status"):
-            self._send(200, {"ok": True, "service": "yasin-coder-gateway"})
+            self._send(200, {"ok": True, "service": "yasin-coder-gateway", "routing": self.gateway.routing()})
+            return
+        if self.path in ("/api/routing", "/v1/routing"):
+            self._send(200, {"ok": True, "routing": self.gateway.routing()})
             return
         if self.path in ("/v1/models", "/api/models"):
             try:
                 models = self.gateway.models()  # type: ignore[union-attr]
                 self._send(200, {"object": "list", "data": models})
-            except Exception as exc:
-                self._send(500, {"error": {"code": "internal_error", "message": str(exc)}})
+            except Exception:
+                self._send(500, {"error": {"code": "internal_error", "message": "Unable to list models"}})
             return
         self._send(404, {"error": {"code": "not_found", "message": "Route not found"}})
 
@@ -118,8 +129,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(200, result)
             except GatewayError as exc:
                 self._send(exc.status, {"error": {"code": exc.code, "message": exc.message}})
-            except Exception as exc:
-                self._send(500, {"error": {"code": "internal_error", "message": str(exc)}})
+            except Exception:
+                self._send(500, {"error": {"code": "internal_error", "message": "Gateway request failed"}})
             return
         self._send(404, {"error": {"code": "not_found", "message": "Route not found"}})
 

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -34,6 +34,9 @@ class ProviderManager:
             return bool(CF_ACCOUNT_ID and CF_API_TOKEN)
         return ModelEndpoint(model).health()
 
+    def routing(self):
+        return dict(self.last_routing)
+
     def _configured_models(self):
         models = {m.get("name"): m for m in self.models.list() if m.get("name")}
         if CF_ACCOUNT_ID and CF_API_TOKEN and "cloudflare" not in models:
@@ -51,14 +54,13 @@ class ProviderManager:
             return self.providers["cloudflare"].chat(prompt)
         raise ValueError("unsupported provider type")
 
-    def ask(self, prompt):
-        selected = MODEL.strip() if MODEL.strip() and MODEL.strip() != "auto" else None
+    def ask(self, prompt, model_name=None):
+        selected = model_name or (MODEL.strip() if MODEL.strip() and MODEL.strip() != "auto" else None)
         primary = self.models.get(selected) if selected else self.models.default()
         if not primary:
-            self.last_routing = {"selected": None, "attempts": [], "offline": False}
+            self.last_routing = {"selected": None, "attempts": [], "offline": False, "error": "configuration"}
             return "No AI model configured. Run model setup or set YASIN_BASE_URL/YASIN_MODEL_NAME."
 
-        # Offline mode is explicit and never consults cloud providers.
         offline = bool(primary.get("offline", False))
         if offline and primary.get("type") == "cloudflare":
             raise RoutingError("configuration", "Offline mode cannot use a cloud provider")
@@ -70,7 +72,7 @@ class ProviderManager:
         except RoutingError as exc:
             self.last_routing = {
                 "selected": None,
-                "attempts": [a.__dict__ for a in getattr(exc, "attempts", [])],
+                "attempts": [a.__dict__ for a in exc.attempts],
                 "offline": offline,
                 "error": exc.kind,
             }

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -2,15 +2,17 @@ from models.manager import ModelManager
 from providers.cloudflare import CloudflareProvider
 from providers.model_endpoint import ModelEndpoint
 from config import MODEL, CF_ACCOUNT_ID, CF_API_TOKEN
+from routing import Router, RoutingError
 
 
 class ProviderManager:
-    """Select configured providers without embedding machine-specific models."""
+    """Select configured providers with deterministic, loop-free fallback."""
 
     def __init__(self):
         self.models = ModelManager()
         self.models.ensure_discovered()
         self.providers = {"cloudflare": CloudflareProvider()}
+        self.last_routing = {"selected": None, "attempts": [], "offline": False}
 
     def list_models(self):
         return self.models.list()
@@ -32,19 +34,51 @@ class ProviderManager:
             return bool(CF_ACCOUNT_ID and CF_API_TOKEN)
         return ModelEndpoint(model).health()
 
-    def ask(self, prompt):
-        selected = MODEL.strip() if MODEL.strip() and MODEL.strip() != "auto" else None
-        model = self.models.get(selected) if selected else self.models.default()
+    def _configured_models(self):
+        models = {m.get("name"): m for m in self.models.list() if m.get("name")}
+        if CF_ACCOUNT_ID and CF_API_TOKEN and "cloudflare" not in models:
+            models["cloudflare"] = {"name": "cloudflare", "type": "cloudflare"}
+        return models
 
-        if model and model.get("type") in {"llama_cpp", "ollama", "openai_compatible"}:
+    def _ask_model(self, model, prompt):
+        kind = model.get("type")
+        if kind in {"llama_cpp", "ollama", "openai_compatible"}:
             endpoint = ModelEndpoint(model)
             if not endpoint.health():
-                return f"Model '{model.get('name')}' is unavailable; configure another model."
+                raise ConnectionError("provider unavailable")
             return endpoint.chat(prompt)
-
-        if model and model.get("type") == "cloudflare":
+        if kind == "cloudflare":
             return self.providers["cloudflare"].chat(prompt)
+        raise ValueError("unsupported provider type")
 
-        if CF_ACCOUNT_ID and CF_API_TOKEN:
-            return self.providers["cloudflare"].chat(prompt)
-        return "No AI model configured. Run model setup or set YASIN_BASE_URL/YASIN_MODEL_NAME."
+    def ask(self, prompt):
+        selected = MODEL.strip() if MODEL.strip() and MODEL.strip() != "auto" else None
+        primary = self.models.get(selected) if selected else self.models.default()
+        if not primary:
+            self.last_routing = {"selected": None, "attempts": [], "offline": False}
+            return "No AI model configured. Run model setup or set YASIN_BASE_URL/YASIN_MODEL_NAME."
+
+        # Offline mode is explicit and never consults cloud providers.
+        offline = bool(primary.get("offline", False))
+        if offline and primary.get("type") == "cloudflare":
+            raise RoutingError("configuration", "Offline mode cannot use a cloud provider")
+
+        resolver_models = self._configured_models()
+        router = Router(lambda name: resolver_models.get(name) or self.models.get(name))
+        try:
+            result = router.run(primary, lambda model: self._ask_model(model, prompt))
+        except RoutingError as exc:
+            self.last_routing = {
+                "selected": None,
+                "attempts": [a.__dict__ for a in getattr(exc, "attempts", [])],
+                "offline": offline,
+                "error": exc.kind,
+            }
+            raise
+
+        self.last_routing = {
+            "selected": result.selected,
+            "attempts": [a.__dict__ for a in result.attempts],
+            "offline": offline,
+        }
+        return result.output

--- a/routing.py
+++ b/routing.py
@@ -10,24 +10,24 @@ from typing import Callable, Iterable
 
 
 TRANSIENT = {"timeout", "network", "server"}
-NON_TRANSIENT = {"quota", "auth", "model", "configuration", "invalid_request"}
 
 
 class RoutingError(RuntimeError):
-    def __init__(self, kind: str, message: str):
+    def __init__(self, kind: str, message: str, attempts: list["RouteAttempt"] | None = None):
         super().__init__(message)
         self.kind = kind
         self.message = message
+        self.attempts = attempts or []
 
 
 def classify_error(exc: Exception) -> str:
     """Classify provider failures without exposing credentials or raw payloads."""
     import urllib.error
 
-    if isinstance(exc, (TimeoutError, TimeoutError)):
+    if isinstance(exc, TimeoutError):
         return "timeout"
     if isinstance(exc, urllib.error.HTTPError):
-        if exc.code == 401 or exc.code == 403:
+        if exc.code in {401, 403}:
             return "auth"
         if exc.code == 429:
             return "quota"
@@ -88,11 +88,7 @@ class Router:
         return result
 
     def run(self, primary: dict, ask: Callable[[dict], str]) -> RoutingResult:
-        if primary.get("offline") is True:
-            chain = [primary]
-        else:
-            chain = self.order(primary)
-
+        chain = [primary] if primary.get("offline") is True else self.order(primary)
         attempts: list[RouteAttempt] = []
         for model in chain:
             name = str(model.get("name") or model.get("model") or "unknown")
@@ -104,7 +100,7 @@ class Router:
                 kind = classify_error(exc)
                 attempts.append(RouteAttempt(name, kind, kind if kind != "provider" else "provider_error"))
                 if kind not in TRANSIENT:
-                    raise RoutingError(kind, f"Provider '{name}' failed: {kind}") from exc
+                    raise RoutingError(kind, f"Provider '{name}' failed: {kind}", attempts) from exc
 
         last = attempts[-1] if attempts else None
-        raise RoutingError(last.outcome if last else "configuration", "No provider succeeded")
+        raise RoutingError(last.outcome if last else "configuration", "No provider succeeded", attempts)

--- a/routing.py
+++ b/routing.py
@@ -1,0 +1,110 @@
+"""Deterministic routing and fallback policy for YasinCoder.
+
+Routing is configuration-driven. Only transient provider failures are eligible
+for fallback; quota/auth/model/configuration errors stop the chain immediately.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable
+
+
+TRANSIENT = {"timeout", "network", "server"}
+NON_TRANSIENT = {"quota", "auth", "model", "configuration", "invalid_request"}
+
+
+class RoutingError(RuntimeError):
+    def __init__(self, kind: str, message: str):
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+
+
+def classify_error(exc: Exception) -> str:
+    """Classify provider failures without exposing credentials or raw payloads."""
+    import urllib.error
+
+    if isinstance(exc, (TimeoutError, TimeoutError)):
+        return "timeout"
+    if isinstance(exc, urllib.error.HTTPError):
+        if exc.code == 401 or exc.code == 403:
+            return "auth"
+        if exc.code == 429:
+            return "quota"
+        if exc.code in {408, 409, 425, 500, 502, 503, 504}:
+            return "server"
+        if exc.code == 404:
+            return "model"
+        return "provider"
+    if isinstance(exc, urllib.error.URLError):
+        return "network"
+
+    text = str(exc).lower()
+    if any(token in text for token in ("quota", "rate limit", "429", "too many requests")):
+        return "quota"
+    if any(token in text for token in ("unauthorized", "forbidden", "api key", "authentication")):
+        return "auth"
+    if any(token in text for token in ("timeout", "timed out")):
+        return "timeout"
+    if any(token in text for token in ("connection", "network", "dns", "fetch failed")):
+        return "network"
+    if any(token in text for token in ("model not found", "unknown model", "does not exist")):
+        return "model"
+    return "provider"
+
+
+@dataclass
+class RouteAttempt:
+    model: str
+    outcome: str
+    error: str | None = None
+
+
+@dataclass
+class RoutingResult:
+    output: str
+    selected: str
+    attempts: list[RouteAttempt] = field(default_factory=list)
+
+
+class Router:
+    """Execute an ordered, loop-free fallback chain."""
+
+    def __init__(self, resolver: Callable[[str], dict | None]):
+        self.resolver = resolver
+
+    def order(self, primary: dict, configured: Iterable[str] | None = None) -> list[dict]:
+        names = [primary.get("name", "")]
+        names.extend(str(x) for x in (configured or primary.get("fallbacks", [])) if str(x))
+        result: list[dict] = []
+        seen: set[str] = set()
+        for name in names:
+            if name in seen:
+                continue
+            seen.add(name)
+            model = self.resolver(name)
+            if model:
+                result.append(model)
+        return result
+
+    def run(self, primary: dict, ask: Callable[[dict], str]) -> RoutingResult:
+        if primary.get("offline") is True:
+            chain = [primary]
+        else:
+            chain = self.order(primary)
+
+        attempts: list[RouteAttempt] = []
+        for model in chain:
+            name = str(model.get("name") or model.get("model") or "unknown")
+            try:
+                output = ask(model)
+                attempts.append(RouteAttempt(name, "success"))
+                return RoutingResult(str(output), name, attempts)
+            except Exception as exc:
+                kind = classify_error(exc)
+                attempts.append(RouteAttempt(name, kind, kind if kind != "provider" else "provider_error"))
+                if kind not in TRANSIENT:
+                    raise RoutingError(kind, f"Provider '{name}' failed: {kind}") from exc
+
+        last = attempts[-1] if attempts else None
+        raise RoutingError(last.outcome if last else "configuration", "No provider succeeded")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,77 @@
+import json
+import urllib.error
+
+import pytest
+
+from routing import Router, RoutingError, classify_error
+
+
+def http_error(code):
+    return urllib.error.HTTPError("http://example", code, "error", {}, None)
+
+
+def test_transient_failure_falls_back_once():
+    models = {
+        "primary": {"name": "primary", "type": "openai_compatible", "fallbacks": ["backup"]},
+        "backup": {"name": "backup", "type": "openai_compatible"},
+    }
+    calls = []
+
+    def ask(model):
+        calls.append(model["name"])
+        if model["name"] == "primary":
+            raise TimeoutError("timed out")
+        return "ok"
+
+    result = Router(models.get).run(models["primary"], ask)
+    assert result.output == "ok"
+    assert result.selected == "backup"
+    assert [a.outcome for a in result.attempts] == ["timeout", "success"]
+    assert calls == ["primary", "backup"]
+
+
+def test_quota_does_not_fallback():
+    models = {
+        "primary": {"name": "primary", "type": "openai_compatible", "fallbacks": ["backup"]},
+        "backup": {"name": "backup", "type": "openai_compatible"},
+    }
+    calls = []
+
+    def ask(model):
+        calls.append(model["name"])
+        raise http_error(429)
+
+    with pytest.raises(RoutingError) as caught:
+        Router(models.get).run(models["primary"], ask)
+
+    assert caught.value.kind == "quota"
+    assert len(caught.value.attempts) == 1
+    assert calls == ["primary"]
+
+
+def test_fallback_chain_is_loop_free():
+    models = {
+        "a": {"name": "a", "fallbacks": ["b"]},
+        "b": {"name": "b", "fallbacks": ["a"]},
+    }
+    assert [m["name"] for m in Router(models.get).order(models["a"])] == ["a", "b"]
+
+
+def test_offline_mode_never_adds_fallbacks():
+    primary = {"name": "local", "offline": True, "fallbacks": ["cloud"]}
+    calls = []
+
+    def ask(model):
+        calls.append(model["name"])
+        raise TimeoutError("offline local unavailable")
+
+    with pytest.raises(RoutingError):
+        Router(lambda name: {"name": name}).run(primary, ask)
+    assert calls == ["local"]
+
+
+def test_error_classification():
+    assert classify_error(http_error(429)) == "quota"
+    assert classify_error(http_error(401)) == "auth"
+    assert classify_error(http_error(503)) == "server"
+    assert classify_error(http_error(404)) == "model"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,7 +1,5 @@
-import json
+import unittest
 import urllib.error
-
-import pytest
 
 from routing import Router, RoutingError, classify_error
 
@@ -10,68 +8,69 @@ def http_error(code):
     return urllib.error.HTTPError("http://example", code, "error", {}, None)
 
 
-def test_transient_failure_falls_back_once():
-    models = {
-        "primary": {"name": "primary", "type": "openai_compatible", "fallbacks": ["backup"]},
-        "backup": {"name": "backup", "type": "openai_compatible"},
-    }
-    calls = []
+class RoutingTests(unittest.TestCase):
+    def test_transient_failure_falls_back_once(self):
+        models = {
+            "primary": {"name": "primary", "type": "openai_compatible", "fallbacks": ["backup"]},
+            "backup": {"name": "backup", "type": "openai_compatible"},
+        }
+        calls = []
 
-    def ask(model):
-        calls.append(model["name"])
-        if model["name"] == "primary":
-            raise TimeoutError("timed out")
-        return "ok"
+        def ask(model):
+            calls.append(model["name"])
+            if model["name"] == "primary":
+                raise TimeoutError("timed out")
+            return "ok"
 
-    result = Router(models.get).run(models["primary"], ask)
-    assert result.output == "ok"
-    assert result.selected == "backup"
-    assert [a.outcome for a in result.attempts] == ["timeout", "success"]
-    assert calls == ["primary", "backup"]
+        result = Router(models.get).run(models["primary"], ask)
+        self.assertEqual(result.output, "ok")
+        self.assertEqual(result.selected, "backup")
+        self.assertEqual([a.outcome for a in result.attempts], ["timeout", "success"])
+        self.assertEqual(calls, ["primary", "backup"])
+
+    def test_quota_does_not_fallback(self):
+        models = {
+            "primary": {"name": "primary", "type": "openai_compatible", "fallbacks": ["backup"]},
+            "backup": {"name": "backup", "type": "openai_compatible"},
+        }
+        calls = []
+
+        def ask(model):
+            calls.append(model["name"])
+            raise http_error(429)
+
+        with self.assertRaises(RoutingError) as caught:
+            Router(models.get).run(models["primary"], ask)
+
+        self.assertEqual(caught.exception.kind, "quota")
+        self.assertEqual(len(caught.exception.attempts), 1)
+        self.assertEqual(calls, ["primary"])
+
+    def test_fallback_chain_is_loop_free(self):
+        models = {
+            "a": {"name": "a", "fallbacks": ["b"]},
+            "b": {"name": "b", "fallbacks": ["a"]},
+        }
+        self.assertEqual([m["name"] for m in Router(models.get).order(models["a"])], ["a", "b"])
+
+    def test_offline_mode_never_adds_fallbacks(self):
+        primary = {"name": "local", "offline": True, "fallbacks": ["cloud"]}
+        calls = []
+
+        def ask(model):
+            calls.append(model["name"])
+            raise TimeoutError("offline local unavailable")
+
+        with self.assertRaises(RoutingError):
+            Router(lambda name: {"name": name}).run(primary, ask)
+        self.assertEqual(calls, ["local"])
+
+    def test_error_classification(self):
+        self.assertEqual(classify_error(http_error(429)), "quota")
+        self.assertEqual(classify_error(http_error(401)), "auth")
+        self.assertEqual(classify_error(http_error(503)), "server")
+        self.assertEqual(classify_error(http_error(404)), "model")
 
 
-def test_quota_does_not_fallback():
-    models = {
-        "primary": {"name": "primary", "type": "openai_compatible", "fallbacks": ["backup"]},
-        "backup": {"name": "backup", "type": "openai_compatible"},
-    }
-    calls = []
-
-    def ask(model):
-        calls.append(model["name"])
-        raise http_error(429)
-
-    with pytest.raises(RoutingError) as caught:
-        Router(models.get).run(models["primary"], ask)
-
-    assert caught.value.kind == "quota"
-    assert len(caught.value.attempts) == 1
-    assert calls == ["primary"]
-
-
-def test_fallback_chain_is_loop_free():
-    models = {
-        "a": {"name": "a", "fallbacks": ["b"]},
-        "b": {"name": "b", "fallbacks": ["a"]},
-    }
-    assert [m["name"] for m in Router(models.get).order(models["a"])] == ["a", "b"]
-
-
-def test_offline_mode_never_adds_fallbacks():
-    primary = {"name": "local", "offline": True, "fallbacks": ["cloud"]}
-    calls = []
-
-    def ask(model):
-        calls.append(model["name"])
-        raise TimeoutError("offline local unavailable")
-
-    with pytest.raises(RoutingError):
-        Router(lambda name: {"name": name}).run(primary, ask)
-    assert calls == ["local"]
-
-
-def test_error_classification():
-    assert classify_error(http_error(429)) == "quota"
-    assert classify_error(http_error(401)) == "auth"
-    assert classify_error(http_error(503)) == "server"
-    assert classify_error(http_error(404)) == "model"
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #8

- Add provider-agnostic deterministic routing with ordered, loop-free fallbacks.
- Retry only transient timeout/network/server failures.
- Stop on quota, auth, model, and configuration failures.
- Enforce offline mode as local-only with no cloud fallback.
- Expose sanitized routing state through the gateway.
- Document external fallback configuration.
- Add standard-library routing tests.