### PR TITLE
Phase 11 — Security hardening and threat model

### DIFF
--- a/config.example
+++ b/config.example
@@ -11,6 +11,12 @@ YASIN_MODELS_FILE=
 YASIN_TEMPERATURE=0.2
 YASIN_MAX_TOKENS=4096
 
+# Gateway security: local-only is the default. Set a key before exposing it remotely.
+# YASIN_API_KEY=replace-with-a-random-secret
+# Comma-separated browser origins; empty means no cross-origin browser access.
+YASIN_ALLOWED_ORIGINS=
+YASIN_MAX_BODY_BYTES=1048576
+
 # Routing policy is stored with the external model definition, not in Git.
 # Example models.json entry:
 # {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,38 @@
+# YasinCoder Security Model
+
+## Trust boundaries
+
+- The gateway is bound to `127.0.0.1` by default.
+- Provider credentials and model definitions live outside Git.
+- Local model weights are ignored by Git and are user-owned runtime data.
+- The coding-agent layer must treat model output as untrusted input.
+
+## Gateway policy
+
+- No CORS origins are allowed unless `YASIN_ALLOWED_ORIGINS` is explicitly set.
+- `YASIN_API_KEY` enables Bearer-token authentication for all gateway routes.
+- Request bodies are capped by `YASIN_MAX_BODY_BYTES` (1 MiB by default).
+- JSON requests must be objects and model identifiers are length-limited.
+- Static file paths are resolved and constrained beneath the web root.
+- Security headers are emitted on gateway responses.
+
+## Remote exposure
+
+Do not bind the gateway to a public interface without authentication and an explicit origin policy. A reverse proxy, TLS termination, firewall, and network access control should be used for production remote deployments.
+
+## Secrets
+
+Never commit API keys, provider tokens, model credentials, local model weights, runtime state, or logs. Use environment variables or an external runtime configuration file.
+
+## Threats addressed in Phase 11
+
+- Cross-origin browser abuse
+- Unauthenticated remote API access
+- Oversized request bodies
+- Malformed JSON and oversized model identifiers
+- Static path traversal
+- Accidental secret/model artifact commits
+
+## Remaining agent-execution boundary
+
+Future sandboxed execution must use explicit workspace allowlists, command allowlists/deny-lists, timeouts, resource limits, and user approval for privileged operations. Provider output must never be treated as a trusted shell command by default.

--- a/gateway.py
+++ b/gateway.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from providers.manager import ProviderManager
 from routing import RoutingError
+from security import DEFAULT_SECURITY_POLICY, SecurityPolicy
 
 WEB_ROOT = Path(__file__).resolve().parent / "web"
 
@@ -38,12 +39,14 @@ class Gateway:
 
     def chat(self, payload: dict[str, Any]) -> dict[str, Any]:
         messages = payload.get("messages")
-        if not isinstance(messages, list) or not messages:
-            raise GatewayError("invalid_request", "messages must be a non-empty list")
+        if not isinstance(messages, list) or not messages or len(messages) > 128:
+            raise GatewayError("invalid_request", "messages must be a non-empty list with at most 128 items")
         text = "\n".join(str(m.get("content", "")) for m in messages if isinstance(m, dict))
         if not text.strip():
             raise GatewayError("invalid_request", "messages contain no text content")
         requested = payload.get("model")
+        if requested is not None and (not isinstance(requested, str) or len(requested) > 256):
+            raise GatewayError("invalid_request", "model must be a short string")
         model = self.manager.models.get(requested) if requested else self.manager.models.default()
         if requested and not model:
             raise GatewayError("model_not_found", f"Model '{requested}' is not configured", 404)
@@ -64,12 +67,29 @@ class Gateway:
 
 class Handler(BaseHTTPRequestHandler):
     gateway: Gateway | None = None
+    security: SecurityPolicy = DEFAULT_SECURITY_POLICY
     server_version = "YasinCoderGateway/1.0"
 
     def _send(self, status: int, data: dict[str, Any]) -> None:
         body = json.dumps(data, ensure_ascii=False).encode()
-        self.send_response(status); self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Cache-Control", "no-store"); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
+        self.send_response(status)
+        for key, value in self.security.public_headers(self.headers.get("Origin")).items():
+            self.send_header(key, value)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _authorized(self) -> bool:
+        origin = self.headers.get("Origin")
+        if not self.security.origin_allowed(origin):
+            self._send(403, {"error": {"code": "origin_forbidden", "message": "Origin is not allowed"}})
+            return False
+        if not self.security.authenticate(self.headers.get("Authorization", "").removeprefix("Bearer ").strip()):
+            self._send(401, {"error": {"code": "unauthorized", "message": "Authentication required"}})
+            return False
+        return True
 
     def _static(self) -> bool:
         path = self.path.split("?", 1)[0]
@@ -79,10 +99,23 @@ class Handler(BaseHTTPRequestHandler):
         if WEB_ROOT not in target.parents and target != WEB_ROOT: return False
         if not target.is_file(): return False
         body = target.read_bytes(); ctype = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
-        self.send_response(200); self.send_header("Content-Type", ctype); self.send_header("Cache-Control", "no-store")
+        self.send_response(200)
+        for key, value in self.security.public_headers(self.headers.get("Origin")).items():
+            self.send_header(key, value)
+        self.send_header("Content-Type", ctype); self.send_header("Cache-Control", "no-store")
         self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body); return True
 
+    def do_OPTIONS(self) -> None:
+        if not self._authorized(): return
+        self.send_response(204)
+        for key, value in self.security.public_headers(self.headers.get("Origin")).items():
+            self.send_header(key, value)
+        self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.end_headers()
+
     def do_GET(self) -> None:
+        if not self._authorized(): return
         if self._static(): return
         if self.path in ("/health", "/api/status"):
             self._send(200, {"ok": True, "service": "yasin-coder-gateway", "routing": self.gateway.routing()}); return
@@ -95,8 +128,16 @@ class Handler(BaseHTTPRequestHandler):
         self._send(404, {"error": {"code": "not_found", "message": "Route not found"}})
 
     def do_POST(self) -> None:
-        try: payload = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))) or b"{}")
-        except (ValueError, json.JSONDecodeError): self._send(400, {"error": {"code": "invalid_json", "message": "Request body must be JSON"}}); return
+        if not self._authorized(): return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            if length < 0 or length > self.security.max_body_bytes:
+                self._send(413, {"error": {"code": "payload_too_large", "message": "Request body is too large"}}); return
+            payload = json.loads(self.rfile.read(length) or b"{}")
+            if not isinstance(payload, dict):
+                self._send(400, {"error": {"code": "invalid_json", "message": "Request body must be a JSON object"}}); return
+        except (ValueError, json.JSONDecodeError):
+            self._send(400, {"error": {"code": "invalid_json", "message": "Request body must be JSON"}}); return
         if self.path in ("/v1/chat/completions", "/api/chat"):
             try: self._send(200, self.gateway.chat(payload))
             except GatewayError as exc: self._send(exc.status, {"error": {"code": exc.code, "message": exc.message}})
@@ -107,8 +148,11 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: Any) -> None: return
 
 
-def create_server(host: str = "127.0.0.1", port: int = 18765, manager: ProviderManager | None = None):
-    Handler.gateway = Gateway(manager); return ThreadingHTTPServer((host, port), Handler)
+def create_server(host: str = "127.0.0.1", port: int = 18765, manager: ProviderManager | None = None,
+                  security: SecurityPolicy | None = None):
+    Handler.gateway = Gateway(manager)
+    Handler.security = security or SecurityPolicy.from_env()
+    return ThreadingHTTPServer((host, port), Handler)
 
 
 def main() -> None:

--- a/security.py
+++ b/security.py
@@ -1,0 +1,48 @@
+"""Security policy helpers for the YasinCoder gateway.
+
+The gateway is local-only by default. Remote access and browser origins are
+opt-in through environment variables. Secrets are never returned by these
+helpers and API authentication uses a constant-time comparison.
+"""
+from __future__ import annotations
+
+import hmac
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SecurityPolicy:
+    api_key: str = ""
+    allowed_origins: tuple[str, ...] = ()
+    max_body_bytes: int = 1_048_576
+
+    @classmethod
+    def from_env(cls) -> "SecurityPolicy":
+        raw_origins = os.getenv("YASIN_ALLOWED_ORIGINS", "").strip()
+        origins = tuple(x.strip() for x in raw_origins.split(",") if x.strip())
+        try:
+            max_body = max(1024, int(os.getenv("YASIN_MAX_BODY_BYTES", "1048576")))
+        except ValueError:
+            max_body = 1_048_576
+        return cls(os.getenv("YASIN_API_KEY", ""), origins, max_body)
+
+    def authenticate(self, supplied: str | None) -> bool:
+        if not self.api_key:
+            return True
+        return bool(supplied) and hmac.compare_digest(supplied, self.api_key)
+
+    def origin_allowed(self, origin: str | None) -> bool:
+        if not origin:
+            return True
+        return not self.allowed_origins or origin in self.allowed_origins
+
+    def public_headers(self, origin: str | None = None) -> dict[str, str]:
+        headers = {"X-Content-Type-Options": "nosniff", "X-Frame-Options": "DENY", "Referrer-Policy": "no-referrer"}
+        if origin and origin in self.allowed_origins:
+            headers["Access-Control-Allow-Origin"] = origin
+            headers["Vary"] = "Origin"
+        return headers
+
+
+DEFAULT_SECURITY_POLICY = SecurityPolicy.from_env()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,31 @@
+import unittest
+
+from security import SecurityPolicy
+
+
+class SecurityPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.policy = SecurityPolicy(
+            api_key="secret",
+            allowed_origins=("https://example.test",),
+            max_body_bytes=4096,
+        )
+
+    def test_authentication_is_required_when_key_configured(self):
+        self.assertFalse(self.policy.authenticate(None))
+        self.assertFalse(self.policy.authenticate("wrong"))
+        self.assertTrue(self.policy.authenticate("secret"))
+
+    def test_origin_policy_is_allowlist(self):
+        self.assertTrue(self.policy.origin_allowed(None))
+        self.assertTrue(self.policy.origin_allowed("https://example.test"))
+        self.assertFalse(self.policy.origin_allowed("https://evil.test"))
+
+    def test_security_headers_do_not_leak_secrets(self):
+        headers = self.policy.public_headers("https://example.test")
+        self.assertNotIn("secret", str(headers))
+        self.assertEqual(headers["Access-Control-Allow-Origin"], "https://example.test")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #15

- Add local-first security policy with optional Bearer authentication.
- Restrict browser CORS to an explicit allowlist.
- Add request-size and JSON/object validation.
- Preserve static path traversal protection and add security headers.
- Document trust boundaries, remote exposure, secrets, and agent-execution risks.
- Add deterministic security policy unit tests.

Validation: code paths and deterministic tests added; runtime CI will be covered by the dedicated testing phase.