### PR TITLE
Phase 3.2 — Implement provider-neutral AI adapters

### DIFF
--- a/models/manager.py
+++ b/models/manager.py
@@ -1,14 +1,12 @@
 """Portable model registry and runtime discovery.
 
-Machine-specific model definitions live outside the repository. The registry
-uses XDG_CONFIG_HOME (or ~/.config) and can be overridden with
-YASIN_MODELS_FILE for tests or custom deployments.
+Machine-specific model definitions live outside the repository. Discovery never
+assumes a developer model name; local runtimes advertise their own models.
 """
 from __future__ import annotations
 
 import json
 import os
-import shutil
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -52,6 +50,7 @@ class ModelManager:
     def upsert(self, model: dict[str, Any]) -> dict[str, Any]:
         if not model.get("name") or not model.get("type"):
             raise ValueError("model requires name and type")
+        model = dict(model)
         models = self.data["models"]
         for i, current in enumerate(models):
             if current.get("name") == model["name"]:
@@ -84,36 +83,43 @@ class ModelManager:
         name = os.getenv("YASIN_MODEL", "").strip() or self.data.get("default", "")
         return self.get(name) if name else (self.data["models"][0] if self.data["models"] else None)
 
+    @staticmethod
+    def _json(base: str, path: str) -> dict[str, Any] | None:
+        try:
+            with urllib.request.urlopen(base.rstrip("/") + path, timeout=2) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except Exception:
+            return None
+
+    def _discover_openai_models(self, base: str) -> list[str]:
+        data = self._json(base, "/v1/models") or {}
+        values = data.get("data") or data.get("models") or []
+        names = []
+        for item in values:
+            if isinstance(item, dict) and item.get("id"):
+                names.append(str(item["id"]))
+            elif isinstance(item, dict) and item.get("name"):
+                names.append(str(item["name"]))
+        return names
+
     def discover(self) -> list[dict[str, Any]]:
         found: list[dict[str, Any]] = []
         env_url = os.getenv("YASIN_BASE_URL", "").strip()
         env_model = os.getenv("YASIN_MODEL_NAME", "").strip()
         if env_url:
             found.append({"name": env_model or "configured-endpoint", "type": "openai_compatible", "base_url": env_url, "model": env_model})
-        probes = [
-            ("llama-cpp", "http://127.0.0.1:18080", "qwen3-local"),
-            ("ollama", "http://127.0.0.1:11434", ""),
-        ]
-        for name, base, model in probes:
-            if self._healthy(base):
-                found.append({"name": name, "type": "ollama" if name == "ollama" else "llama_cpp", "base_url": base, "model": model})
+
+        for base, kind in (("http://127.0.0.1:18080", "llama_cpp"), ("http://127.0.0.1:11434", "ollama")):
+            names = self._discover_openai_models(base) if kind == "llama_cpp" else []
+            if kind == "ollama":
+                data = self._json(base, "/api/tags") or {}
+                names = [str(x.get("name")) for x in data.get("models", []) if isinstance(x, dict) and x.get("name")]
+            for model_name in names:
+                found.append({"name": f"{kind}:{model_name}", "type": kind, "base_url": base, "model": model_name, "offline": True})
         return found
 
-    @staticmethod
-    def _healthy(base: str) -> bool:
-        for endpoint in ("/health", "/api/tags", "/v1/models"):
-            try:
-                with urllib.request.urlopen(base.rstrip("/") + endpoint, timeout=1.5) as response:
-                    if 200 <= response.status < 300:
-                        return True
-            except Exception:
-                continue
-        return False
-
     def ensure_discovered(self) -> list[dict[str, Any]]:
-        discovered = []
-        for model in self.discover():
-            discovered.append(self.upsert(model))
+        discovered = [self.upsert(model) for model in self.discover()]
         if not self.default() and discovered:
             self.select(discovered[0]["name"])
         return discovered

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,0 +1,21 @@
+from .base import (
+    ModelInfo,
+    ProviderAdapter,
+    ProviderAuthenticationError,
+    ProviderConfigurationError,
+    ProviderError,
+    ProviderRequestError,
+    ProviderUnavailable,
+)
+from .factory import create_adapter
+
+__all__ = [
+    "ModelInfo",
+    "ProviderAdapter",
+    "ProviderError",
+    "ProviderAuthenticationError",
+    "ProviderConfigurationError",
+    "ProviderRequestError",
+    "ProviderUnavailable",
+    "create_adapter",
+]

--- a/providers/base.py
+++ b/providers/base.py
@@ -1,7 +1,70 @@
-class BaseProvider:
+"""Provider-neutral adapter contract and normalized provider errors."""
+from __future__ import annotations
 
-    name="base"
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
 
-    def chat(self,prompt):
 
+class ProviderError(RuntimeError):
+    kind = "provider_error"
+
+    def __init__(self, message: str, *, status: int | None = None):
+        super().__init__(message)
+        self.status = status
+
+
+class ProviderUnavailable(ProviderError):
+    kind = "unavailable"
+
+
+class ProviderAuthenticationError(ProviderError):
+    kind = "authentication"
+
+
+class ProviderConfigurationError(ProviderError):
+    kind = "configuration"
+
+
+class ProviderRequestError(ProviderError):
+    kind = "request"
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    name: str
+    provider: str
+    model: str
+    offline: bool
+    capabilities: tuple[str, ...] = ("chat",)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "provider": self.provider, "model": self.model, "offline": self.offline, "capabilities": list(self.capabilities)}
+
+
+class ProviderAdapter(ABC):
+    """Stable interface consumed by gateway and routing layers."""
+    provider_type = "unknown"
+    offline = False
+
+    def __init__(self, model: dict[str, Any]):
+        self.model = model
+
+    @property
+    def name(self) -> str:
+        return str(self.model.get("name") or self.model.get("model") or self.provider_type)
+
+    @property
+    def model_name(self) -> str:
+        return str(self.model.get("model") or self.name)
+
+    @abstractmethod
+    def health(self) -> bool:
         raise NotImplementedError
+
+    @abstractmethod
+    def chat(self, prompt: str) -> str:
+        raise NotImplementedError
+
+    def info(self) -> ModelInfo:
+        return ModelInfo(self.name, self.provider_type, self.model_name, self.offline)

--- a/providers/cloudflare.py
+++ b/providers/cloudflare.py
@@ -1,65 +1,49 @@
+"""Cloudflare Workers AI adapter."""
+from __future__ import annotations
+
 import json
+import urllib.error
 import urllib.request
-from config import CF_ACCOUNT_ID,CF_API_TOKEN,CF_MODEL
+from typing import Any
 
-class CloudflareProvider:
+from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
 
-    def chat(self,prompt):
 
-        if not CF_ACCOUNT_ID or not CF_API_TOKEN:
+class CloudflareProvider(ProviderAdapter):
+    provider_type = "cloudflare"
+    offline = False
 
-            return "Cloudflare not configured: set CF_ACCOUNT_ID and CF_API_TOKEN in config.py"
+    def __init__(self, model: dict[str, Any] | None = None):
+        model = dict(model or {})
+        super().__init__(model)
+        self.account_id = str(model.get("account_id", ""))
+        self.api_token = str(model.get("api_token", ""))
+        self.model_name = str(model.get("model") or model.get("name") or "")
+        self.timeout = float(model.get("timeout", 120))
 
-        url=f"https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}/ai/run/{CF_MODEL}"
+    def health(self) -> bool:
+        return bool(self.account_id and self.api_token and self.model_name)
 
-        data=json.dumps({
-
-            "messages":[
-
-                {
-
-                    "role":"user",
-
-                    "content":prompt
-
-                }
-
-            ]
-
-        }).encode()
-
-        req=urllib.request.Request(
-
-            url,
-
-            data=data,
-
-            headers={
-
-                "Authorization":"Bearer "+CF_API_TOKEN,
-
-                "Content-Type":"application/json"
-
-            }
-
-        )
-
+    def chat(self, prompt: str) -> str:
+        if not self.account_id or not self.api_token or not self.model_name:
+            raise ProviderConfigurationError("Cloudflare account, token and model must be configured")
+        url = f"https://api.cloudflare.com/client/v4/accounts/{self.account_id}/ai/run/{self.model_name}"
+        payload = {"messages": [{"role": "user", "content": prompt}]}
+        request = urllib.request.Request(url, data=json.dumps(payload).encode(), headers={"Authorization": "Bearer " + self.api_token, "Content-Type": "application/json"})
         try:
-
-            with urllib.request.urlopen(req,timeout=120) as r:
-
-                result=json.loads(r.read().decode())
-
-            if "result" in result:
-
-                if "response" in result["result"]:
-
-                    return result["result"]["response"]
-
-                return str(result["result"])
-
-            return str(result)
-
-        except Exception as e:
-
-            return "Cloudflare Error: "+str(e)
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                data = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise ProviderAuthenticationError("Cloudflare authentication failed", status=exc.code) from None
+            raise ProviderRequestError(f"Cloudflare returned HTTP {exc.code}", status=exc.code) from None
+        except (urllib.error.URLError, TimeoutError, OSError):
+            raise ProviderUnavailable("Cloudflare is unavailable") from None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise ProviderRequestError("Cloudflare returned invalid JSON") from None
+        result = data.get("result") or {}
+        if "response" in result:
+            return str(result["response"])
+        if isinstance(result, dict) and result.get("output"):
+            return str(result["output"])
+        raise ProviderRequestError("Cloudflare returned no model output")

--- a/providers/cloudflare.py
+++ b/providers/cloudflare.py
@@ -18,8 +18,12 @@ class CloudflareProvider(ProviderAdapter):
         super().__init__(model)
         self.account_id = str(model.get("account_id", ""))
         self.api_token = str(model.get("api_token", ""))
-        self.model_name = str(model.get("model") or model.get("name") or "")
+        self._model_name = str(model.get("model") or model.get("name") or "")
         self.timeout = float(model.get("timeout", 120))
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
 
     def health(self) -> bool:
         return bool(self.account_id and self.api_token and self.model_name)
@@ -44,6 +48,6 @@ class CloudflareProvider(ProviderAdapter):
         result = data.get("result") or {}
         if "response" in result:
             return str(result["response"])
-        if isinstance(result, dict) and result.get("output"):
+        if result.get("output"):
             return str(result["output"])
         raise ProviderRequestError("Cloudflare returned no model output")

--- a/providers/factory.py
+++ b/providers/factory.py
@@ -1,0 +1,23 @@
+"""Construct adapters from portable model configuration."""
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ProviderConfigurationError, ProviderAdapter
+from .http_compatible import OpenAICompatibleAdapter
+from .llama_cpp import LlamaCppAdapter
+from .ollama import OllamaAdapter
+
+
+def create_adapter(model: dict[str, Any]) -> ProviderAdapter:
+    kind = str(model.get("type", "")).strip().lower()
+    if kind == "llama_cpp":
+        return LlamaCppAdapter(model)
+    if kind == "ollama":
+        return OllamaAdapter(model)
+    if kind in {"openai_compatible", "openai", "custom"}:
+        return OpenAICompatibleAdapter(model)
+    if kind == "cloudflare":
+        from .cloudflare import CloudflareProvider
+        return CloudflareProvider(model)
+    raise ProviderConfigurationError(f"unsupported provider type: {kind or 'empty'}")

--- a/providers/http_compatible.py
+++ b/providers/http_compatible.py
@@ -6,7 +6,7 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
+from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderError, ProviderRequestError, ProviderUnavailable
 
 
 class OpenAICompatibleAdapter(ProviderAdapter):
@@ -62,5 +62,4 @@ class OpenAICompatibleAdapter(ProviderAdapter):
         if not choices:
             raise ProviderRequestError("provider returned no choices")
         message = choices[0].get("message") or {}
-        content = message.get("content", "")
-        return str(content)
+        return str(message.get("content", ""))

--- a/providers/http_compatible.py
+++ b/providers/http_compatible.py
@@ -1,0 +1,66 @@
+"""HTTP adapter for OpenAI-compatible local and remote endpoints."""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
+
+
+class OpenAICompatibleAdapter(ProviderAdapter):
+    provider_type = "openai_compatible"
+
+    def __init__(self, model: dict[str, Any], *, provider_type: str | None = None, offline: bool = False):
+        super().__init__(model)
+        self.provider_type = provider_type or str(model.get("provider") or self.provider_type)
+        self.offline = offline
+        self.base_url = str(model.get("base_url", "")).rstrip("/")
+        self.api_key = str(model.get("api_key", ""))
+        self.timeout = float(model.get("timeout", 120))
+
+    def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        if not self.base_url:
+            raise ProviderConfigurationError("provider base_url is not configured")
+        headers = {"Accept": "application/json"}
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+        if self.api_key:
+            headers["Authorization"] = "Bearer " + self.api_key
+        request = urllib.request.Request(self.base_url + path, data=json.dumps(payload).encode() if payload is not None else None, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise ProviderAuthenticationError("provider authentication failed", status=exc.code) from None
+            raise ProviderRequestError(f"provider returned HTTP {exc.code}", status=exc.code) from None
+        except (urllib.error.URLError, TimeoutError, OSError):
+            raise ProviderUnavailable("provider is unavailable") from None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise ProviderRequestError("provider returned invalid JSON") from None
+
+    def health(self) -> bool:
+        for path in ("/health", "/v1/models", "/api/tags"):
+            try:
+                self._request(path)
+                return True
+            except ProviderError:
+                continue
+        return False
+
+    def chat(self, prompt: str) -> str:
+        payload = {
+            "model": self.model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": self.model.get("temperature", 0.2),
+            "max_tokens": self.model.get("max_tokens", 4096),
+        }
+        data = self._request("/v1/chat/completions", payload)
+        choices = data.get("choices") or []
+        if not choices:
+            raise ProviderRequestError("provider returned no choices")
+        message = choices[0].get("message") or {}
+        content = message.get("content", "")
+        return str(content)

--- a/providers/llama_cpp.py
+++ b/providers/llama_cpp.py
@@ -1,0 +1,14 @@
+"""llama.cpp server adapter using its OpenAI-compatible API."""
+from __future__ import annotations
+
+from typing import Any
+
+from .http_compatible import OpenAICompatibleAdapter
+
+
+class LlamaCppAdapter(OpenAICompatibleAdapter):
+    provider_type = "llama_cpp"
+    offline = True
+
+    def __init__(self, model: dict[str, Any]):
+        super().__init__(model, provider_type="llama_cpp", offline=True)

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -1,17 +1,20 @@
+"""Provider registry and adapter orchestration."""
+from __future__ import annotations
+
+from config import CF_ACCOUNT_ID, CF_API_TOKEN, CF_MODEL, MODEL
 from models.manager import ModelManager
-from providers.cloudflare import CloudflareProvider
-from providers.model_endpoint import ModelEndpoint
-from config import MODEL, CF_ACCOUNT_ID, CF_API_TOKEN
 from routing import Router, RoutingError
+
+from .base import ProviderError, ProviderUnavailable
+from .factory import create_adapter
 
 
 class ProviderManager:
-    """Select configured providers with deterministic, loop-free fallback."""
+    """Select configured models while keeping gateway code provider-neutral."""
 
     def __init__(self):
         self.models = ModelManager()
         self.models.ensure_discovered()
-        self.providers = {"cloudflare": CloudflareProvider()}
         self.last_routing = {"selected": None, "attempts": [], "offline": False}
 
     def list_models(self):
@@ -26,61 +29,48 @@ class ProviderManager:
     def select(self, name):
         return self.models.select(name)
 
+    def _configured_models(self):
+        models = {m.get("name"): m for m in self.models.list() if m.get("name")}
+        if CF_ACCOUNT_ID and CF_API_TOKEN and CF_MODEL and "cloudflare" not in models:
+            models["cloudflare"] = {"name": "cloudflare", "type": "cloudflare", "model": CF_MODEL, "account_id": CF_ACCOUNT_ID, "api_token": CF_API_TOKEN}
+        return models
+
+    def _adapter(self, model):
+        return create_adapter(model)
+
     def health(self, name=None):
         model = self.models.get(name) if name else self.models.default()
         if not model:
             return False
-        if model.get("type") == "cloudflare":
-            return bool(CF_ACCOUNT_ID and CF_API_TOKEN)
-        return ModelEndpoint(model).health()
+        try:
+            return self._adapter(model).health()
+        except ProviderError:
+            return False
 
     def routing(self):
         return dict(self.last_routing)
 
-    def _configured_models(self):
-        models = {m.get("name"): m for m in self.models.list() if m.get("name")}
-        if CF_ACCOUNT_ID and CF_API_TOKEN and "cloudflare" not in models:
-            models["cloudflare"] = {"name": "cloudflare", "type": "cloudflare"}
-        return models
-
     def _ask_model(self, model, prompt):
-        kind = model.get("type")
-        if kind in {"llama_cpp", "ollama", "openai_compatible"}:
-            endpoint = ModelEndpoint(model)
-            if not endpoint.health():
-                raise ConnectionError("provider unavailable")
-            return endpoint.chat(prompt)
-        if kind == "cloudflare":
-            return self.providers["cloudflare"].chat(prompt)
-        raise ValueError("unsupported provider type")
+        adapter = self._adapter(model)
+        if not adapter.health():
+            raise ProviderUnavailable("provider is unavailable")
+        return adapter.chat(prompt)
 
     def ask(self, prompt, model_name=None):
         selected = model_name or (MODEL.strip() if MODEL.strip() and MODEL.strip() != "auto" else None)
         primary = self.models.get(selected) if selected else self.models.default()
         if not primary:
             self.last_routing = {"selected": None, "attempts": [], "offline": False, "error": "configuration"}
-            return "No AI model configured. Run model setup or set YASIN_BASE_URL/YASIN_MODEL_NAME."
+            return "No AI model configured. Configure a local or online provider first."
 
         offline = bool(primary.get("offline", False))
-        if offline and primary.get("type") == "cloudflare":
-            raise RoutingError("configuration", "Offline mode cannot use a cloud provider")
-
         resolver_models = self._configured_models()
         router = Router(lambda name: resolver_models.get(name) or self.models.get(name))
         try:
             result = router.run(primary, lambda model: self._ask_model(model, prompt))
         except RoutingError as exc:
-            self.last_routing = {
-                "selected": None,
-                "attempts": [a.__dict__ for a in exc.attempts],
-                "offline": offline,
-                "error": exc.kind,
-            }
+            self.last_routing = {"selected": None, "attempts": [a.__dict__ for a in exc.attempts], "offline": offline, "error": exc.kind}
             raise
 
-        self.last_routing = {
-            "selected": result.selected,
-            "attempts": [a.__dict__ for a in result.attempts],
-            "offline": offline,
-        }
+        self.last_routing = {"selected": result.selected, "attempts": [a.__dict__ for a in result.attempts], "offline": offline}
         return result.output

--- a/providers/ollama.py
+++ b/providers/ollama.py
@@ -1,0 +1,50 @@
+"""Ollama-native provider adapter."""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
+
+
+class OllamaAdapter(ProviderAdapter):
+    provider_type = "ollama"
+    offline = True
+
+    def __init__(self, model: dict[str, Any]):
+        super().__init__(model)
+        self.base_url = str(model.get("base_url", "http://127.0.0.1:11434")).rstrip("/")
+        self.timeout = float(model.get("timeout", 120))
+        self.api_key = str(model.get("api_key", ""))
+
+    def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        if not self.base_url:
+            raise ProviderConfigurationError("Ollama base_url is not configured")
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = "Bearer " + self.api_key
+        request = urllib.request.Request(self.base_url + path, data=json.dumps(payload).encode() if payload is not None else None, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise ProviderAuthenticationError("Ollama authentication failed", status=exc.code) from None
+            raise ProviderRequestError(f"Ollama returned HTTP {exc.code}", status=exc.code) from None
+        except (urllib.error.URLError, TimeoutError, OSError):
+            raise ProviderUnavailable("Ollama is unavailable") from None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise ProviderRequestError("Ollama returned invalid JSON") from None
+
+    def health(self) -> bool:
+        try:
+            self._request("/api/tags")
+            return True
+        except Exception:
+            return False
+
+    def chat(self, prompt: str) -> str:
+        data = self._request("/api/generate", {"model": self.model_name, "prompt": prompt, "stream": False})
+        return str(data.get("response", ""))

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -1,8 +1,7 @@
 import json
 import urllib.error
+import unittest
 from unittest.mock import patch
-
-import pytest
 
 from providers.base import ProviderAuthenticationError, ProviderUnavailable
 from providers.factory import create_adapter
@@ -27,31 +26,33 @@ class Response:
         return json.dumps(self.payload).encode()
 
 
-def test_factory_selects_local_adapters():
-    llama = create_adapter({"name": "local", "type": "llama_cpp", "base_url": "http://local", "model": "m"})
-    ollama = create_adapter({"name": "local", "type": "ollama", "base_url": "http://local", "model": "m"})
-    assert isinstance(llama, LlamaCppAdapter)
-    assert isinstance(ollama, OllamaAdapter)
-    assert llama.offline and ollama.offline
+class ProviderAdapterTests(unittest.TestCase):
+    def test_factory_selects_local_adapters(self):
+        llama = create_adapter({"name": "local", "type": "llama_cpp", "base_url": "http://local", "model": "m"})
+        ollama = create_adapter({"name": "local", "type": "ollama", "base_url": "http://local", "model": "m"})
+        self.assertIsInstance(llama, LlamaCppAdapter)
+        self.assertIsInstance(ollama, OllamaAdapter)
+        self.assertTrue(llama.offline and ollama.offline)
+
+    def test_openai_compatible_chat_normalizes_response(self):
+        adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
+        with patch("urllib.request.urlopen", return_value=Response({"choices": [{"message": {"content": "ok"}}]})):
+            self.assertEqual(adapter.chat("hello"), "ok")
+
+    def test_openai_compatible_auth_error_is_normalized(self):
+        adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
+        error = urllib.error.HTTPError("http://remote", 401, "unauthorized", {}, None)
+        with patch("urllib.request.urlopen", side_effect=error):
+            with self.assertRaises(ProviderAuthenticationError):
+                adapter.chat("hello")
+
+    def test_unavailable_error_does_not_expose_credentials(self):
+        adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m", "api_key": "SECRET"})
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
+            with self.assertRaises(ProviderUnavailable) as context:
+                adapter.chat("hello")
+        self.assertNotIn("SECRET", str(context.exception))
 
 
-def test_openai_compatible_chat_normalizes_response():
-    adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
-    with patch("urllib.request.urlopen", return_value=Response({"choices": [{"message": {"content": "ok"}}]})):
-        assert adapter.chat("hello") == "ok"
-
-
-def test_openai_compatible_auth_error_is_normalized():
-    adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
-    error = urllib.error.HTTPError("http://remote", 401, "unauthorized", {}, None)
-    with patch("urllib.request.urlopen", side_effect=error):
-        with pytest.raises(ProviderAuthenticationError):
-            adapter.chat("hello")
-
-
-def test_unavailable_error_does_not_expose_url_or_credentials():
-    adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m", "api_key": "SECRET"})
-    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
-        with pytest.raises(ProviderUnavailable) as exc:
-            adapter.chat("hello")
-    assert "SECRET" not in str(exc.value)
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -1,0 +1,57 @@
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from providers.base import ProviderAuthenticationError, ProviderUnavailable
+from providers.factory import create_adapter
+from providers.llama_cpp import LlamaCppAdapter
+from providers.ollama import OllamaAdapter
+from providers.http_compatible import OpenAICompatibleAdapter
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
+def test_factory_selects_local_adapters():
+    llama = create_adapter({"name": "local", "type": "llama_cpp", "base_url": "http://local", "model": "m"})
+    ollama = create_adapter({"name": "local", "type": "ollama", "base_url": "http://local", "model": "m"})
+    assert isinstance(llama, LlamaCppAdapter)
+    assert isinstance(ollama, OllamaAdapter)
+    assert llama.offline and ollama.offline
+
+
+def test_openai_compatible_chat_normalizes_response():
+    adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
+    with patch("urllib.request.urlopen", return_value=Response({"choices": [{"message": {"content": "ok"}}]})):
+        assert adapter.chat("hello") == "ok"
+
+
+def test_openai_compatible_auth_error_is_normalized():
+    adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
+    error = urllib.error.HTTPError("http://remote", 401, "unauthorized", {}, None)
+    with patch("urllib.request.urlopen", side_effect=error):
+        with pytest.raises(ProviderAuthenticationError):
+            adapter.chat("hello")
+
+
+def test_unavailable_error_does_not_expose_url_or_credentials():
+    adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m", "api_key": "SECRET"})
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
+        with pytest.raises(ProviderUnavailable) as exc:
+            adapter.chat("hello")
+    assert "SECRET" not in str(exc.value)


### PR DESCRIPTION
Closes #39

Implements the provider-neutral adapter boundary for local and online AI backends, including llama.cpp, Ollama, OpenAI-compatible endpoints, and Cloudflare Workers AI. Adds normalized provider errors, portable local model discovery, adapter factory, and deterministic adapter tests. No model files, device-specific model names, or credentials are committed.