### PR TITLE
Phase 15 — Clean-clone production audit and YasinCoder v1.0

### DIFF
--- a/docs/PRODUCTION_AUDIT.md
+++ b/docs/PRODUCTION_AUDIT.md
@@ -1,0 +1,41 @@
+# YasinCoder Production Audit — Phase 15
+
+## Scope
+
+This document is the final clean-clone production gate for YasinCoder v1.0. It records the repository-level invariants that can be verified from Git and CI without relying on the developer machine, credentials, or a bundled model.
+
+## Gate results
+
+| Gate | Result | Evidence |
+|---|---|---|
+| Architecture/roadmap alignment | PASS | `README.md`, `docs/ARCHITECTURE.md`, phase issues |
+| Model portability | PASS | README and CI clean-clone invariants; no model binaries are required or bundled |
+| Developer-path isolation | PASS | Repository policy and deterministic tests |
+| Secret/config isolation | PASS | `.gitignore`, external/user-owned configuration policy |
+| Python syntax/compile | PASS | CI runs `python -m compileall -q .` |
+| Deterministic test suite | PASS | CI runs `python -m unittest discover -s tests -p 'test_*.py' -v` |
+| Packaging | PASS | `pyproject.toml`, semantic version metadata and release workflow |
+| Release artifacts | PASS | `.github/workflows/release.yml` |
+| Offline/local-model portability | PASS | Local runtime/model remains external to the repository |
+| Online/provider portability | PASS | Provider-agnostic configuration and external credentials |
+| Rollback/release policy | PASS | `docs/RELEASE.md` |
+| YASIN-DOCS synchronization | PASS | Architecture/configuration/gateway contracts are documented in-repo and mirrored to the project documentation set |
+
+## Security gate
+
+The repository must never contain API keys, tokens, GGUF/model binaries, runtime state, logs, caches, or developer-specific absolute paths. The clean-clone contract treats these as user-owned runtime data.
+
+## Model gate
+
+YasinCoder does **not** ship the developer's local model. A fresh user selects either:
+
+- Offline/local AI and supplies/configures their own llama.cpp, Ollama, or compatible local runtime/model.
+- Online AI and supplies a supported provider plus credentials.
+
+Changing the local model must not require source-code edits.
+
+## v1.0 decision
+
+The repository is structurally ready for the v1.0 release gate. Provider credentials and a user's local model are intentionally environment-specific and therefore cannot be treated as repository release blockers.
+
+Future enhancements listed in `TODO.md` remain post-v1.0 work and must be tracked as new issues rather than silently added to this release.

--- a/tests/test_clean_clone.py
+++ b/tests/test_clean_clone.py
@@ -1,0 +1,40 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class CleanCloneProductionGate(unittest.TestCase):
+    def test_required_release_files_exist(self):
+        for name in ("README.md", "LICENSE", "VERSION", "pyproject.toml", "CHANGELOG.md"):
+            self.assertTrue((ROOT / name).is_file(), name)
+
+    def test_required_docs_exist(self):
+        for name in ("ARCHITECTURE.md", "CONFIGURATION.md", "GATEWAY.md", "RELEASE.md", "PRODUCTION_AUDIT.md"):
+            self.assertTrue((ROOT / "docs" / name).is_file(), name)
+
+    def test_model_and_runtime_data_are_not_required_in_tree(self):
+        forbidden_suffixes = {".gguf", ".safetensors"}
+        forbidden_names = {".env"}
+        for path in ROOT.rglob("*"):
+            if not path.is_file():
+                continue
+            self.assertNotIn(path.name, forbidden_names)
+            self.assertNotIn(path.suffix.lower(), forbidden_suffixes)
+
+    def test_no_developer_absolute_path_is_hardcoded(self):
+        forbidden = "/data/data/com.termux/files/home/"
+        for path in ROOT.rglob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn(forbidden, text, str(path))
+
+    def test_version_is_semver(self):
+        version = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
+        parts = version.split(".")
+        self.assertEqual(len(parts), 3)
+        self.assertTrue(all(part.isdigit() for part in parts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_clean_clone.py
+++ b/tests/test_clean_clone.py
@@ -24,7 +24,7 @@ class CleanCloneProductionGate(unittest.TestCase):
             self.assertNotIn(path.suffix.lower(), forbidden_suffixes)
 
     def test_no_developer_absolute_path_is_hardcoded(self):
-        forbidden = "/data/data/com.termux/files/home/"
+        forbidden = "/".join(("data", "data", "com.termux", "files", "home")) + "/"
         for path in ROOT.rglob("*.py"):
             text = path.read_text(encoding="utf-8")
             self.assertNotIn(forbidden, text, str(path))


### PR DESCRIPTION
Closes #19

- Adds the final production audit gate.
- Adds clean-clone invariants covering release files, docs, model/runtime isolation, developer-path isolation, and semantic versioning.
- Documents the v1.0 release/rollback policy.
- Keeps local models, credentials, caches, logs, and runtime state outside Git.