### PR TITLE
Make start.sh portable for clean clones

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,11 @@
-#!/data/data/com.termux/files/usr/bin/bash
+#!/usr/bin/env bash
+set -e
 
-cd ~/YasinCoder
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
-bash install.sh
+if [ -f "$ROOT/.venv/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    . "$ROOT/.venv/bin/activate"
+fi
 
-exec bash
+exec python "$ROOT/main.py" "$@"


### PR DESCRIPTION
Closes #54.

- replace the Termux-specific shebang
- remove the hard-coded `~/YasinCoder` path
- resolve the repository root from the script location
- optionally activate a local `.venv`
- execute `main.py` from the resolved root

Validated against the clean-clone checks: Python compilation, 35 unit tests, secret scan, and developer-specific path scan all pass.