### PR TITLE
fix: complete #57 packaging and installability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,32 @@ AI coding agent with a portable, provider-agnostic architecture.
 
 YasinCoder is being rebuilt as a clean-clone project: runtime state, credentials, caches, logs, and local model files stay outside Git.
 
+## Installation
+
+YasinCoder is a normal Python distribution and can be installed from a clean clone:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install .
+```
+
+For development/editable installs:
+
+```bash
+python -m pip install -e .
+```
+
+After installation, both the public package and CLI are available outside the repository directory:
+
+```bash
+python -c "import yasincoder; print(yasincoder.__version__)"
+yasincoder info
+```
+
+On Windows, activate the virtual environment with `.venv\\Scripts\\activate` instead of `. .venv/bin/activate`.
+
 ## Supported deployment modes
 
 At first run, users will choose:
@@ -41,7 +67,15 @@ python -m compileall -q .
 python -m unittest discover -s tests -p 'test_*.py' -v
 ```
 
-The deterministic suite includes gateway contract/security tests and clean-clone invariants for model portability and developer-path isolation.
+To verify the distribution boundary itself:
+
+```bash
+python -m pip install .
+python -c "import yasincoder"
+yasincoder info
+```
+
+The deterministic suite includes gateway contract/security tests, packaging smoke coverage, and clean-clone invariants for model portability and developer-path isolation.
 
 ## Roadmap
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,33 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 
+[project.scripts]
+yasincoder = "main:main"
+
 [tool.setuptools.dynamic]
 version = { file = "VERSION" }
 
+[tool.setuptools]
+py-modules = [
+    "agent",
+    "ai_client",
+    "backup",
+    "coding_agent",
+    "config",
+    "doctor",
+    "gateway",
+    "git_manager",
+    "main",
+    "memory",
+    "project",
+    "router",
+    "routing",
+    "security",
+    "task_manager",
+]
+
 [tool.setuptools.packages.find]
-include = ["core*", "commands*", "providers*"]
+include = ["yasincoder*", "core*", "commands*", "providers*", "models*"]
 
 [tool.yasincoder.release]
 versioning = "semantic"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,34 @@
+import pathlib
+import subprocess
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class PackagingTests(unittest.TestCase):
+    def test_public_package_exists(self):
+        package = ROOT / "yasincoder" / "__init__.py"
+        self.assertTrue(package.is_file())
+
+    def test_pyproject_declares_cli_and_package(self):
+        text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        self.assertIn('[project.scripts]', text)
+        self.assertIn('yasincoder = "main:main"', text)
+        self.assertIn('"yasincoder*"', text)
+        self.assertIn('"models*"', text)
+
+    def test_source_tree_import_smoke(self):
+        result = subprocess.run(
+            [sys.executable, "-c", "import yasincoder; assert yasincoder.__version__"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yasincoder/__init__.py
+++ b/yasincoder/__init__.py
@@ -1,0 +1,16 @@
+"""Public package interface for YasinCoder.
+
+The implementation remains split into the project's stable top-level modules
+and subpackages for backwards compatibility, while this package provides a
+real importable distribution boundary.
+"""
+from __future__ import annotations
+
+try:
+    from importlib.metadata import version as _distribution_version
+
+    __version__ = _distribution_version("yasincoder")
+except Exception:  # pragma: no cover - source-tree fallback
+    __version__ = "0.1.0"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
Closes #57

- adds a real importable `yasincoder` package boundary
- configures setuptools to package top-level implementation modules and subpackages
- adds the `yasincoder` CLI entry point
- includes model namespace package discovery
- adds packaging/import smoke tests
- documents clean and editable installation

Verification: source-level packaging smoke coverage is included. External runtime installation could not be executed in this environment because outbound DNS/network access is unavailable.