### PR TITLE
fix: complete #58 configuration and model registry

### DIFF
--- a/commands/models.py
+++ b/commands/models.py
@@ -6,10 +6,12 @@ class ModelsCommand:
         self.manager = manager or ModelManager()
 
     def run(self):
+        default = self.manager.default()
         return {
-            "default": self.manager.data.get("default", ""),
+            "default": default.get("name", "") if default else "",
             "models": self.manager.list(),
             "config_file": str(self.manager.path),
+            "validation_errors": self.manager.validate_all(),
         }
 
     def discover(self):
@@ -23,3 +25,6 @@ class ModelsCommand:
 
     def select(self, name):
         return self.manager.select(name)
+
+    def validate(self):
+        return self.manager.validate_all()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,34 +1,72 @@
 # YasinCoder Configuration Contract
 
+YasinCoder keeps provider configuration in a user-owned registry outside the repository.
+
+## Model registry
+
+The default file is `~/.config/yasin-coder/models.json` on Linux/Termux and follows `XDG_CONFIG_HOME` when set. Override it with `YASIN_MODELS_FILE`.
+
+A model entry has a stable `name`, provider `type`, optional `model`, `base_url`, `aliases`, `timeout`, `temperature`, `max_tokens`, and provider metadata. Supported types are `openai_compatible`, `openai`, `custom`, `ollama`, `llama_cpp`, and `cloudflare`.
+
+Example:
+
+```json
+{
+  "version": 2,
+  "default": "local",
+  "models": [
+    {
+      "name": "local",
+      "type": "ollama",
+      "model": "qwen3",
+      "aliases": ["qwen"],
+      "timeout": 120,
+      "temperature": 0.2,
+      "max_tokens": 4096
+    }
+  ]
+}
+```
+
 ## Environment variables
 
-| Variable | Purpose | Example |
-|---|---|---|
-| `YASIN_PROJECT_PATH` | Workspace/project root | `/home/user/project` |
-| `YASIN_MODEL` | Provider/model selection | `auto` |
-| `YASIN_BASE_URL` | OpenAI-compatible/custom endpoint | `http://127.0.0.1:18080/v1` |
-| `YASIN_API_KEY` | Provider credential | user supplied |
-| `YASIN_TEMPERATURE` | Generation temperature | `0.2` |
-| `YASIN_MAX_TOKENS` | Output token budget | `4096` |
-| `CF_ACCOUNT_ID` | Cloudflare account | user supplied |
-| `CF_API_TOKEN` | Cloudflare credential | user supplied |
-| `CF_MODEL` | Cloudflare model | provider-specific |
+| Variable | Purpose |
+|---|---|
+| `YASIN_PROJECT_PATH` | Workspace/project root |
+| `YASIN_MODEL` | Provider/model selection by name or alias |
+| `YASIN_MODEL_NAME` | Model advertised by `YASIN_BASE_URL` |
+| `YASIN_BASE_URL` | OpenAI-compatible/custom endpoint |
+| `YASIN_API_KEY` | Credential, referenced as `api_key_env` |
+| `YASIN_TEMPERATURE` | Generation temperature |
+| `YASIN_MAX_TOKENS` | Output token budget |
+| `YASIN_TIMEOUT` | Provider request timeout |
+| `CF_ACCOUNT_ID` | Cloudflare account, referenced as `account_id_env` |
+| `CF_API_TOKEN` | Cloudflare credential, referenced as `api_token_env` |
+| `CF_MODEL` | Cloudflare model |
 
-## Local AI
+## Secrets
 
-YasinCoder does not ship a model. Users may point it at their own llama.cpp,
-Ollama, or another compatible local server. The model path, endpoint, alias,
-context size and runtime flags belong to the user's machine configuration.
+Never put API keys or tokens in `models.json`. Use environment references such as `api_key_env`, `api_token_env`, or `account_id_env`. The registry stores only the variable name; runtime code resolves the value from the process environment.
 
-For example, a user can configure a local OpenAI-compatible endpoint without
-changing application source. The model can be Qwen, Llama, Gemma, Mistral or
-another compatible model.
+```bash
+export YASIN_BASE_URL=https://example.invalid/v1
+export YASIN_MODEL_NAME=my-model
+export YASIN_API_KEY='...'
+```
 
-## Online AI
+## Selection
 
-The first-run wizard will expose supported online providers. Provider-specific
-credentials are entered by the user and stored through the runtime's secret
-configuration mechanism, never in Git.
+Selection order is deterministic:
+
+1. `YASIN_MODEL` when it matches a model name or alias.
+2. The persisted `default` entry.
+3. The first model sorted by name.
+
+Run `python main.py models` to inspect the registry without printing secret values. Run `python main.py doctor` to validate configuration and get first-run guidance.
+
+## Discovery
+
+YasinCoder can discover a configured `YASIN_BASE_URL` endpoint and local models exposed by llama.cpp (`127.0.0.1:18080`) or Ollama (`127.0.0.1:11434`). Discovery writes only non-secret model metadata and environment-variable references to the user registry.
 
 ## Rules
 

--- a/doctor.py
+++ b/doctor.py
@@ -1,56 +1,47 @@
+"""Environment and model configuration diagnostics."""
+from __future__ import annotations
+
 import os
 import sys
 
-print("="*60)
-print("YasinCoder Doctor")
-print("="*60)
+from models.manager import ModelManager, ModelValidationError
 
-print("Python :",sys.version)
 
-folders=[
+def run() -> int:
+    print("=" * 60)
+    print("YasinCoder Doctor")
+    print("=" * 60)
+    print("Python :", sys.version.split()[0])
 
-"commands",
+    folders = ["commands", "core", "providers", "models"]
+    for folder in folders:
+        print("[ OK ]" if os.path.isdir(folder) else "[FAIL]", folder)
 
-"core",
+    files = ["main.py", "router.py", "agent.py", "project.py", "config.py", "ai_client.py"]
+    for file in files:
+        print("[ OK ]" if os.path.isfile(file) else "[FAIL]", file)
 
-"providers",
+    try:
+        manager = ModelManager()
+        errors = manager.validate_all()
+        default = manager.default()
+        print("Models :", len(manager.list()))
+        print("Config :", manager.path)
+        print("Default:", default.get("name") if default else "NOT CONFIGURED")
+        if errors:
+            print("[FAIL] Model validation:")
+            for error in errors:
+                print("  -", error)
+            return 1
+        if not default:
+            print("[INFO] No model configured. Set YASIN_BASE_URL/YASIN_MODEL_NAME or add a model to the user registry.")
+        else:
+            print("[ OK ] Model registry")
+        return 0
+    except ModelValidationError as exc:
+        print("[FAIL] Model registry:", exc)
+        return 1
 
-"prompts"
 
-]
-
-for folder in folders:
-
-    if os.path.isdir(folder):
-
-        print("[ OK ]",folder)
-
-    else:
-
-        print("[FAIL]",folder)
-
-files=[
-
-"main.py",
-
-"router.py",
-
-"agent.py",
-
-"project.py",
-
-"config.py",
-
-"ai_client.py"
-
-]
-
-for file in files:
-
-    if os.path.isfile(file):
-
-        print("[ OK ]",file)
-
-    else:
-
-        print("[FAIL]",file)
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/main.py
+++ b/main.py
@@ -1,9 +1,6 @@
 import sys
 
-from router import Router
-
 from core.banner import show
-
 from commands.help import HelpCommand
 from commands.info import InfoCommand
 from commands.models import ModelsCommand
@@ -17,102 +14,56 @@ from commands.fix import FixCommand
 from commands.refactor import RefactorCommand
 from commands.explain import ExplainCommand
 
+
 def main():
-
     show()
-
-    if len(sys.argv)==1:
-
+    if len(sys.argv) == 1:
         print(HelpCommand().run())
-
         return
 
-    cmd=sys.argv[1]
-
-    if cmd=="help":
-
+    cmd = sys.argv[1]
+    if cmd == "help":
         print(HelpCommand().run())
-
-    elif cmd=="info":
-
+    elif cmd == "info":
         print(InfoCommand().run())
-
-    elif cmd=="models":
-
+    elif cmd == "models":
         print(ModelsCommand().run())
-
-    elif cmd=="project":
-
+    elif cmd == "doctor":
+        from doctor import run as doctor_run
+        raise SystemExit(doctor_run())
+    elif cmd == "project":
         print(ProjectCommand().run())
-
-    elif cmd=="brain":
-
-        brain=BrainCommand().run()
-
-        print("FILES:",len(brain))
-
+    elif cmd == "brain":
+        brain = BrainCommand().run()
+        print("FILES:", len(brain))
         for item in brain:
-
             print(item["file"])
-
-    elif cmd=="search":
-
-        if len(sys.argv)<3:
-
+    elif cmd == "search":
+        if len(sys.argv) < 3:
             print("Usage: search keyword")
-
             return
-
-        result=SearchCommand().run(sys.argv[2])
-
-        for file in result:
-
+        for file in SearchCommand().run(sys.argv[2]):
             print(file)
-
-    elif cmd=="read":
-
-        if len(sys.argv)<3:
-
+    elif cmd == "read":
+        if len(sys.argv) < 3:
             print("Usage: read filename.py")
-
             return
-
         print(ReadCommand().run(sys.argv[2]))
-
-    elif cmd=="chat":
-
-        prompt=" ".join(sys.argv[2:])
-
-        print(ChatCommand().run(prompt))
-
-    elif cmd=="review":
-
+    elif cmd == "chat":
+        print(ChatCommand().run(" ".join(sys.argv[2:])))
+    elif cmd == "review":
         print(ReviewCommand().run(sys.argv[2]))
-
-    elif cmd=="fix":
-
+    elif cmd == "fix":
         print(FixCommand().run(sys.argv[2]))
-
-    elif cmd=="refactor":
-
+    elif cmd == "refactor":
         print(RefactorCommand().run(sys.argv[2]))
-
-    elif cmd=="explain":
-
-        filename=sys.argv[2]
-
-        question="Explain this file."
-
-        if len(sys.argv)>3:
-
-            question=" ".join(sys.argv[3:])
-
-        print(ExplainCommand().run(filename,question))
-
+    elif cmd == "explain":
+        filename = sys.argv[2]
+        question = " ".join(sys.argv[3:]) if len(sys.argv) > 3 else "Explain this file."
+        print(ExplainCommand().run(filename, question))
     else:
-
         print("Unknown command.")
 
-if __name__=="__main__":
 
+if __name__ == "__main__":
     main()

--- a/models/manager.py
+++ b/models/manager.py
@@ -1,8 +1,4 @@
-"""Portable model registry and runtime discovery.
-
-Machine-specific model definitions live outside the repository. Discovery never
-assumes a developer model name; local runtimes advertise their own models.
-"""
+"""Portable model registry, validation, secret references and discovery."""
 from __future__ import annotations
 
 import json
@@ -13,58 +9,124 @@ from typing import Any
 
 DEFAULT_CONFIG_DIR = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config")) / "yasin-coder"
 DEFAULT_MODELS_FILE = DEFAULT_CONFIG_DIR / "models.json"
+SCHEMA_VERSION = 2
+SECRET_KEYS = {"api_key", "api_token", "token", "password", "secret"}
+SUPPORTED_TYPES = {"openai_compatible", "openai", "custom", "ollama", "llama_cpp", "cloudflare"}
 
 
 def _path() -> Path:
     return Path(os.getenv("YASIN_MODELS_FILE", str(DEFAULT_MODELS_FILE))).expanduser()
 
 
+def _default_data() -> dict[str, Any]:
+    return {"version": SCHEMA_VERSION, "default": "", "models": []}
+
+
+class ModelValidationError(ValueError):
+    """Raised when a model definition is invalid or unsafe to persist."""
+
+
 class ModelManager:
+    """User-owned registry. Secrets are referenced by environment variable only."""
+
     def __init__(self, path: str | Path | None = None):
         self.path = Path(path).expanduser() if path else _path()
         self.data = self._load()
 
     def _load(self) -> dict[str, Any]:
         if not self.path.exists():
-            return {"version": 1, "default": "", "models": []}
+            return _default_data()
         try:
             data = json.loads(self.path.read_text(encoding="utf-8"))
-            if isinstance(data, dict) and isinstance(data.get("models"), list):
-                return data
-        except (OSError, ValueError):
-            pass
-        return {"version": 1, "default": "", "models": []}
+        except (OSError, ValueError) as exc:
+            raise ModelValidationError(f"cannot read model registry {self.path}: {exc}") from exc
+        if not isinstance(data, dict) or not isinstance(data.get("models"), list):
+            raise ModelValidationError("model registry must contain an object with a models list")
+        data.setdefault("version", SCHEMA_VERSION)
+        data.setdefault("default", "")
+        for model in data["models"]:
+            self.validate(model)
+        return data
+
+    @staticmethod
+    def validate(model: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(model, dict):
+            raise ModelValidationError("model definition must be an object")
+        name = str(model.get("name", "")).strip()
+        kind = str(model.get("type", "")).strip().lower()
+        if not name:
+            raise ModelValidationError("model requires a non-empty name")
+        if not kind or kind not in SUPPORTED_TYPES:
+            raise ModelValidationError(f"unsupported provider type: {kind or '<empty>'}")
+        for key in SECRET_KEYS:
+            if key in model and model[key]:
+                raise ModelValidationError(f"secret value '{key}' must not be stored; use an *_ENV reference")
+        aliases = model.get("aliases", [])
+        if isinstance(aliases, str):
+            aliases = [aliases]
+            model["aliases"] = aliases
+        if not isinstance(aliases, list) or not all(isinstance(x, str) and x.strip() for x in aliases):
+            raise ModelValidationError("aliases must be a list of non-empty strings")
+        if "base_url" in model and model["base_url"] and not isinstance(model["base_url"], str):
+            raise ModelValidationError("base_url must be a string")
+        for key in ("timeout", "temperature"):
+            if key in model:
+                try:
+                    value = float(model[key])
+                except (TypeError, ValueError) as exc:
+                    raise ModelValidationError(f"{key} must be numeric") from exc
+                if value < 0:
+                    raise ModelValidationError(f"{key} must be >= 0")
+        if "max_tokens" in model:
+            try:
+                if int(model["max_tokens"]) <= 0:
+                    raise ValueError
+            except (TypeError, ValueError) as exc:
+                raise ModelValidationError("max_tokens must be a positive integer") from exc
+        for key, value in model.items():
+            if key.endswith("_env") and value and (not isinstance(value, str) or not value.strip()):
+                raise ModelValidationError(f"{key} must name an environment variable")
+        return model
 
     def save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(".tmp")
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
         tmp.write_text(json.dumps(self.data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
         tmp.replace(self.path)
 
     def list(self) -> list[dict[str, Any]]:
-        return list(self.data["models"])
+        return sorted((dict(m) for m in self.data["models"]), key=lambda m: str(m.get("name", "")).lower())
 
     def get(self, name: str) -> dict[str, Any] | None:
-        return next((m for m in self.data["models"] if m.get("name") == name), None)
+        needle = str(name).strip().lower()
+        for model in self.data["models"]:
+            if str(model.get("name", "")).lower() == needle:
+                return dict(model)
+            if needle in {str(alias).strip().lower() for alias in model.get("aliases", [])}:
+                return dict(model)
+        return None
 
     def upsert(self, model: dict[str, Any]) -> dict[str, Any]:
-        if not model.get("name") or not model.get("type"):
-            raise ValueError("model requires name and type")
         model = dict(model)
+        self.validate(model)
         models = self.data["models"]
         for i, current in enumerate(models):
-            if current.get("name") == model["name"]:
+            if str(current.get("name", "")).lower() == str(model["name"]).lower():
                 models[i] = {**current, **model}
                 self.save()
-                return models[i]
+                return dict(models[i])
         models.append(model)
         self.save()
-        return model
+        return dict(model)
 
     def remove(self, name: str) -> bool:
+        model = self.get(name)
+        if not model:
+            return False
+        target = model["name"]
         before = len(self.data["models"])
-        self.data["models"] = [m for m in self.data["models"] if m.get("name") != name]
-        if self.data.get("default") == name:
+        self.data["models"] = [m for m in self.data["models"] if m.get("name") != target]
+        if self.data.get("default") == target:
             self.data["default"] = ""
         changed = len(self.data["models"]) != before
         if changed:
@@ -74,14 +136,33 @@ class ModelManager:
     def select(self, name: str) -> dict[str, Any]:
         model = self.get(name)
         if not model:
-            raise KeyError(name)
-        self.data["default"] = name
+            raise KeyError(f"unknown model: {name}")
+        self.data["default"] = model["name"]
         self.save()
         return model
 
     def default(self) -> dict[str, Any] | None:
-        name = os.getenv("YASIN_MODEL", "").strip() or self.data.get("default", "")
-        return self.get(name) if name else (self.data["models"][0] if self.data["models"] else None)
+        requested = os.getenv("YASIN_MODEL", "").strip()
+        if requested:
+            return self.get(requested)
+        configured = str(self.data.get("default", "")).strip()
+        if configured:
+            return self.get(configured)
+        models = self.list()
+        return models[0] if models else None
+
+    @staticmethod
+    def resolve_secrets(model: dict[str, Any]) -> dict[str, Any]:
+        """Return a runtime copy with environment-backed credentials resolved."""
+        resolved = dict(model)
+        for key, env_name in list(model.items()):
+            if not key.endswith("_env") or not env_name:
+                continue
+            target = key[:-4]
+            value = os.getenv(str(env_name), "")
+            if value:
+                resolved[target] = value
+        return resolved
 
     @staticmethod
     def _json(base: str, path: str) -> dict[str, Any] | None:
@@ -94,21 +175,27 @@ class ModelManager:
     def _discover_openai_models(self, base: str) -> list[str]:
         data = self._json(base, "/v1/models") or {}
         values = data.get("data") or data.get("models") or []
-        names = []
-        for item in values:
-            if isinstance(item, dict) and item.get("id"):
-                names.append(str(item["id"]))
-            elif isinstance(item, dict) and item.get("name"):
-                names.append(str(item["name"]))
-        return names
+        return [str(x.get("id") or x.get("name")) for x in values if isinstance(x, dict) and (x.get("id") or x.get("name"))]
 
     def discover(self) -> list[dict[str, Any]]:
         found: list[dict[str, Any]] = []
         env_url = os.getenv("YASIN_BASE_URL", "").strip()
         env_model = os.getenv("YASIN_MODEL_NAME", "").strip()
+        env_key = os.getenv("YASIN_API_KEY", "")
         if env_url:
-            found.append({"name": env_model or "configured-endpoint", "type": "openai_compatible", "base_url": env_url, "model": env_model})
-
+            found.append({
+                "name": env_model or "configured-endpoint",
+                "type": "openai_compatible",
+                "base_url": env_url,
+                "model": env_model,
+                "api_key_env": "YASIN_API_KEY" if env_key else "",
+                "timeout": float(os.getenv("YASIN_TIMEOUT", "120")),
+                "temperature": float(os.getenv("YASIN_TEMPERATURE", "0.2")),
+                "max_tokens": int(os.getenv("YASIN_MAX_TOKENS", "4096")),
+            })
+        cf_id, cf_token, cf_model = os.getenv("CF_ACCOUNT_ID", ""), os.getenv("CF_API_TOKEN", ""), os.getenv("CF_MODEL", "")
+        if cf_id and cf_token and cf_model:
+            found.append({"name": "cloudflare", "type": "cloudflare", "model": cf_model, "account_id_env": "CF_ACCOUNT_ID", "api_token_env": "CF_API_TOKEN"})
         for base, kind in (("http://127.0.0.1:18080", "llama_cpp"), ("http://127.0.0.1:11434", "ollama")):
             names = self._discover_openai_models(base) if kind == "llama_cpp" else []
             if kind == "ollama":
@@ -119,7 +206,33 @@ class ModelManager:
         return found
 
     def ensure_discovered(self) -> list[dict[str, Any]]:
-        discovered = [self.upsert(model) for model in self.discover()]
+        discovered = []
+        for model in self.discover():
+            try:
+                discovered.append(self.upsert(model))
+            except ModelValidationError:
+                continue
         if not self.default() and discovered:
-            self.select(discovered[0]["name"])
+            self.select(sorted(discovered, key=lambda x: x["name"].lower())[0]["name"])
         return discovered
+
+    def validate_all(self) -> list[str]:
+        errors = []
+        names: set[str] = set()
+        aliases: dict[str, str] = {}
+        for model in self.data["models"]:
+            try:
+                self.validate(model)
+            except ModelValidationError as exc:
+                errors.append(str(exc))
+                continue
+            name = str(model["name"]).lower()
+            if name in names:
+                errors.append(f"duplicate model name: {model['name']}")
+            names.add(name)
+            for alias in model.get("aliases", []):
+                key = alias.lower()
+                if key in names or (key in aliases and aliases[key] != model["name"]):
+                    errors.append(f"duplicate model alias: {alias}")
+                aliases[key] = model["name"]
+        return errors

--- a/models/manager.py
+++ b/models/manager.py
@@ -143,7 +143,7 @@ class ModelManager:
 
     def default(self) -> dict[str, Any] | None:
         requested = os.getenv("YASIN_MODEL", "").strip()
-        if requested:
+        if requested and requested.lower() != "auto":
             return self.get(requested)
         configured = str(self.data.get("default", "")).strip()
         if configured:
@@ -183,16 +183,7 @@ class ModelManager:
         env_model = os.getenv("YASIN_MODEL_NAME", "").strip()
         env_key = os.getenv("YASIN_API_KEY", "")
         if env_url:
-            found.append({
-                "name": env_model or "configured-endpoint",
-                "type": "openai_compatible",
-                "base_url": env_url,
-                "model": env_model,
-                "api_key_env": "YASIN_API_KEY" if env_key else "",
-                "timeout": float(os.getenv("YASIN_TIMEOUT", "120")),
-                "temperature": float(os.getenv("YASIN_TEMPERATURE", "0.2")),
-                "max_tokens": int(os.getenv("YASIN_MAX_TOKENS", "4096")),
-            })
+            found.append({"name": env_model or "configured-endpoint", "type": "openai_compatible", "base_url": env_url, "model": env_model, "api_key_env": "YASIN_API_KEY" if env_key else "", "timeout": float(os.getenv("YASIN_TIMEOUT", "120")), "temperature": float(os.getenv("YASIN_TEMPERATURE", "0.2")), "max_tokens": int(os.getenv("YASIN_MAX_TOKENS", "4096"))})
         cf_id, cf_token, cf_model = os.getenv("CF_ACCOUNT_ID", ""), os.getenv("CF_API_TOKEN", ""), os.getenv("CF_MODEL", "")
         if cf_id and cf_token and cf_model:
             found.append({"name": "cloudflare", "type": "cloudflare", "model": cf_model, "account_id_env": "CF_ACCOUNT_ID", "api_token_env": "CF_API_TOKEN"})

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,22 +1,79 @@
 import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from models.manager import ModelManager
+from models.manager import ModelManager, ModelValidationError
 
 
-def test_registry_lifecycle(tmp_path):
-    path = tmp_path / "models.json"
-    manager = ModelManager(path)
-    assert manager.list() == []
+class ModelManagerTests(unittest.TestCase):
+    def test_registry_lifecycle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "models.json"
+            manager = ModelManager(path)
+            self.assertEqual(manager.list(), [])
+            manager.upsert({
+                "name": "my-local",
+                "type": "openai_compatible",
+                "base_url": "http://127.0.0.1:9999",
+                "model": "my-model",
+                "aliases": ["local"],
+                "temperature": 0.1,
+                "max_tokens": 1000,
+            })
+            self.assertEqual(manager.get("local")["model"], "my-model")
+            manager.select("local")
+            self.assertEqual(manager.default()["name"], "my-local")
+            reloaded = ModelManager(path)
+            self.assertEqual(reloaded.default()["name"], "my-local")
+            self.assertEqual(json.loads(path.read_text())["default"], "my-local")
+            self.assertTrue(reloaded.remove("local"))
+            self.assertIsNone(reloaded.default())
 
-    manager.upsert({"name": "my-local", "type": "openai_compatible", "base_url": "http://127.0.0.1:9999", "model": "my-model"})
-    assert manager.get("my-local")["model"] == "my-model"
+    def test_secrets_are_rejected_from_persistence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = ModelManager(Path(tmp) / "models.json")
+            with self.assertRaises(ModelValidationError):
+                manager.upsert({"name": "bad", "type": "openai", "api_key": "super-secret"})
+            self.assertFalse((Path(tmp) / "models.json").exists())
 
-    manager.select("my-local")
-    assert manager.default()["name"] == "my-local"
+    def test_secret_environment_reference_is_resolved_only_at_runtime(self):
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(os.environ, {"TEST_YASIN_KEY": "super-secret"}):
+            path = Path(tmp) / "models.json"
+            manager = ModelManager(path)
+            manager.upsert({"name": "remote", "type": "openai", "base_url": "https://example.invalid/v1", "model": "demo", "api_key_env": "TEST_YASIN_KEY"})
+            raw = path.read_text()
+            self.assertNotIn("super-secret", raw)
+            self.assertEqual(manager.get("remote").get("api_key"), None)
+            self.assertEqual(manager.resolve_secrets(manager.get("remote"))["api_key"], "super-secret")
 
-    reloaded = ModelManager(path)
-    assert reloaded.default()["name"] == "my-local"
-    assert json.loads(path.read_text())["default"] == "my-local"
+    def test_environment_model_and_alias_select_deterministically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = ModelManager(Path(tmp) / "models.json")
+            manager.upsert({"name": "zeta", "type": "ollama", "model": "z"})
+            manager.upsert({"name": "alpha", "type": "ollama", "model": "a", "aliases": ["preferred"]})
+            with patch.dict(os.environ, {"YASIN_MODEL": "preferred"}):
+                self.assertEqual(manager.default()["name"], "alpha")
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("YASIN_MODEL", None)
+                manager.data["default"] = ""
+                self.assertEqual(manager.default()["name"], "alpha")
 
-    assert reloaded.remove("my-local") is True
-    assert reloaded.default() is None
+    def test_invalid_configuration_is_actionable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = ModelManager(Path(tmp) / "models.json")
+            cases = [
+                ({"name": "x", "type": "unknown"}, "unsupported provider type"),
+                ({"name": "x", "type": "ollama", "max_tokens": 0}, "max_tokens"),
+                ({"name": "x", "type": "ollama", "api_token": "secret"}, "secret value"),
+            ]
+            for model, message in cases:
+                with self.subTest(model=model):
+                    with self.assertRaisesRegex(ModelValidationError, message):
+                        manager.upsert(model)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #58

- canonical model schema with validation
- deterministic name/alias/default selection
- environment-backed secret references; secret values are rejected from persistence
- OpenAI-compatible, Cloudflare, Ollama and llama.cpp discovery
- model validation surfaced through CLI and doctor
- configuration contract documentation
- deterministic unittest coverage for registry lifecycle, validation and secret handling

Verification: CI will run compile and unittest discovery on the PR.