### PR TITLE
fix: implement provider discovery and production adapters

### DIFF
--- a/models/manager.py
+++ b/models/manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -11,7 +12,15 @@ DEFAULT_CONFIG_DIR = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config"))
 DEFAULT_MODELS_FILE = DEFAULT_CONFIG_DIR / "models.json"
 SCHEMA_VERSION = 2
 SECRET_KEYS = {"api_key", "api_token", "token", "password", "secret"}
-SUPPORTED_TYPES = {"openai_compatible", "openai", "custom", "ollama", "llama_cpp", "cloudflare"}
+SUPPORTED_TYPES = {
+    "openai_compatible",
+    "openai",
+    "custom",
+    "ollama",
+    "llama_cpp",
+    "cloudflare",
+    "gemini",
+}
 
 
 def _path() -> Path:
@@ -165,39 +174,107 @@ class ModelManager:
         return resolved
 
     @staticmethod
-    def _json(base: str, path: str) -> dict[str, Any] | None:
+    def _json(base: str, path: str, *, timeout: float = 3) -> dict[str, Any] | None:
         try:
-            with urllib.request.urlopen(base.rstrip("/") + path, timeout=2) as response:
+            request = urllib.request.Request(base.rstrip("/") + path, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(request, timeout=timeout) as response:
                 return json.loads(response.read().decode("utf-8"))
-        except Exception:
+        except (OSError, ValueError, urllib.error.URLError, urllib.error.HTTPError):
             return None
 
+    @staticmethod
+    def _openai_base(base: str) -> str:
+        return base.rstrip("/")[:-3] if base.rstrip("/").endswith("/v1") else base.rstrip("/")
+
     def _discover_openai_models(self, base: str) -> list[str]:
-        data = self._json(base, "/v1/models") or {}
+        data = self._json(self._openai_base(base), "/v1/models") or {}
         values = data.get("data") or data.get("models") or []
-        return [str(x.get("id") or x.get("name")) for x in values if isinstance(x, dict) and (x.get("id") or x.get("name"))]
+        return [
+            str(x.get("id") or x.get("name"))
+            for x in values
+            if isinstance(x, dict) and (x.get("id") or x.get("name"))
+        ]
+
+    def _discover_ollama_models(self, base: str) -> list[str]:
+        data = self._json(base, "/api/tags") or {}
+        return [
+            str(x.get("name"))
+            for x in data.get("models", [])
+            if isinstance(x, dict) and x.get("name")
+        ]
 
     def discover(self) -> list[dict[str, Any]]:
+        """Discover configured and locally reachable providers without persisting secrets."""
         found: list[dict[str, Any]] = []
+
         env_url = os.getenv("YASIN_BASE_URL", "").strip()
         env_model = os.getenv("YASIN_MODEL_NAME", "").strip()
-        env_key = os.getenv("YASIN_API_KEY", "")
         if env_url:
-            found.append({"name": env_model or "configured-endpoint", "type": "openai_compatible", "base_url": env_url, "model": env_model, "api_key_env": "YASIN_API_KEY" if env_key else "", "timeout": float(os.getenv("YASIN_TIMEOUT", "120")), "temperature": float(os.getenv("YASIN_TEMPERATURE", "0.2")), "max_tokens": int(os.getenv("YASIN_MAX_TOKENS", "4096"))})
-        cf_id, cf_token, cf_model = os.getenv("CF_ACCOUNT_ID", ""), os.getenv("CF_API_TOKEN", ""), os.getenv("CF_MODEL", "")
-        if cf_id and cf_token and cf_model:
-            found.append({"name": "cloudflare", "type": "cloudflare", "model": cf_model, "account_id_env": "CF_ACCOUNT_ID", "api_token_env": "CF_API_TOKEN"})
-        for base, kind in (("http://127.0.0.1:18080", "llama_cpp"), ("http://127.0.0.1:11434", "ollama")):
-            names = self._discover_openai_models(base) if kind == "llama_cpp" else []
-            if kind == "ollama":
-                data = self._json(base, "/api/tags") or {}
-                names = [str(x.get("name")) for x in data.get("models", []) if isinstance(x, dict) and x.get("name")]
+            names = self._discover_openai_models(env_url)
+            if env_model and env_model not in names:
+                names.insert(0, env_model)
+            if not names:
+                names = ["configured-endpoint"] if env_model else []
             for model_name in names:
-                found.append({"name": f"{kind}:{model_name}", "type": kind, "base_url": base, "model": model_name, "offline": True})
+                found.append({
+                    "name": model_name if len(names) == 1 else f"openai:{model_name}",
+                    "type": "openai_compatible",
+                    "base_url": env_url,
+                    "model": model_name if model_name != "configured-endpoint" else env_model,
+                    "api_key_env": "YASIN_API_KEY" if os.getenv("YASIN_API_KEY") else "",
+                    "timeout": float(os.getenv("YASIN_TIMEOUT", "120")),
+                    "temperature": float(os.getenv("YASIN_TEMPERATURE", "0.2")),
+                    "max_tokens": int(os.getenv("YASIN_MAX_TOKENS", "4096")),
+                })
+
+        google_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        if google_key:
+            gemini_base = os.getenv(
+                "GEMINI_BASE_URL",
+                "https://generativelanguage.googleapis.com/v1beta/openai",
+            ).strip()
+            gemini_model = os.getenv("GEMINI_MODEL", "gemini-2.5-flash").strip()
+            names = self._discover_openai_models(gemini_base)
+            if gemini_model and gemini_model not in names:
+                names.insert(0, gemini_model)
+            for model_name in names:
+                found.append({
+                    "name": f"gemini:{model_name}",
+                    "type": "gemini",
+                    "base_url": gemini_base,
+                    "model": model_name,
+                    "api_key_env": "GEMINI_API_KEY" if os.getenv("GEMINI_API_KEY") else "GOOGLE_API_KEY",
+                })
+
+        cf_id = os.getenv("CF_ACCOUNT_ID", "").strip()
+        cf_token = os.getenv("CF_API_TOKEN", "").strip()
+        cf_model = os.getenv("CF_MODEL", "").strip()
+        if cf_id and cf_model:
+            found.append({
+                "name": "cloudflare",
+                "type": "cloudflare",
+                "model": cf_model,
+                "account_id_env": "CF_ACCOUNT_ID",
+                "api_token_env": "CF_API_TOKEN" if cf_token else "",
+            })
+
+        local_endpoints = (
+            ("http://127.0.0.1:18080", "llama_cpp", self._discover_openai_models),
+            ("http://127.0.0.1:11434", "ollama", self._discover_ollama_models),
+        )
+        for base, kind, discoverer in local_endpoints:
+            for model_name in discoverer(base):
+                found.append({
+                    "name": f"{kind}:{model_name}",
+                    "type": kind,
+                    "base_url": base,
+                    "model": model_name,
+                    "offline": True,
+                })
         return found
 
     def ensure_discovered(self) -> list[dict[str, Any]]:
-        discovered = []
+        discovered: list[dict[str, Any]] = []
         for model in self.discover():
             try:
                 discovered.append(self.upsert(model))

--- a/providers/factory.py
+++ b/providers/factory.py
@@ -15,6 +15,8 @@ def create_adapter(model: dict[str, Any]) -> ProviderAdapter:
         return LlamaCppAdapter(model)
     if kind == "ollama":
         return OllamaAdapter(model)
+    if kind == "gemini":
+        return OpenAICompatibleAdapter(model, provider_type="gemini")
     if kind in {"openai_compatible", "openai", "custom"}:
         return OpenAICompatibleAdapter(model)
     if kind == "cloudflare":

--- a/providers/http_compatible.py
+++ b/providers/http_compatible.py
@@ -6,7 +6,14 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderError, ProviderRequestError, ProviderUnavailable
+from .base import (
+    ProviderAdapter,
+    ProviderAuthenticationError,
+    ProviderConfigurationError,
+    ProviderError,
+    ProviderRequestError,
+    ProviderUnavailable,
+)
 
 
 class OpenAICompatibleAdapter(ProviderAdapter):
@@ -20,6 +27,12 @@ class OpenAICompatibleAdapter(ProviderAdapter):
         self.api_key = str(model.get("api_key", ""))
         self.timeout = float(model.get("timeout", 120))
 
+    def _url(self, path: str) -> str:
+        base = self.base_url.rstrip("/")
+        if path.startswith("/v1/") and base.endswith("/v1"):
+            return base + path[3:]
+        return base + path
+
     def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         if not self.base_url:
             raise ProviderConfigurationError("provider base_url is not configured")
@@ -28,29 +41,55 @@ class OpenAICompatibleAdapter(ProviderAdapter):
             headers["Content-Type"] = "application/json"
         if self.api_key:
             headers["Authorization"] = "Bearer " + self.api_key
-        request = urllib.request.Request(self.base_url + path, data=json.dumps(payload).encode() if payload is not None else None, headers=headers)
+        request = urllib.request.Request(
+            self._url(path),
+            data=json.dumps(payload).encode() if payload is not None else None,
+            headers=headers,
+        )
         try:
             with urllib.request.urlopen(request, timeout=self.timeout) as response:
                 return json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
             if exc.code in (401, 403):
                 raise ProviderAuthenticationError("provider authentication failed", status=exc.code) from None
+            if exc.code == 404:
+                raise ProviderRequestError("provider endpoint was not found", status=exc.code) from None
             raise ProviderRequestError(f"provider returned HTTP {exc.code}", status=exc.code) from None
         except (urllib.error.URLError, TimeoutError, OSError):
             raise ProviderUnavailable("provider is unavailable") from None
         except (json.JSONDecodeError, UnicodeDecodeError):
             raise ProviderRequestError("provider returned invalid JSON") from None
 
+    def list_models(self) -> list[str]:
+        data = self._request("/v1/models")
+        values = data.get("data") or data.get("models") or []
+        return [
+            str(item.get("id") or item.get("name"))
+            for item in values
+            if isinstance(item, dict) and (item.get("id") or item.get("name"))
+        ]
+
     def health(self) -> bool:
-        for path in ("/health", "/v1/models", "/api/tags"):
+        try:
+            self._request("/health")
+            return True
+        except ProviderError:
             try:
-                self._request(path)
+                self.list_models()
                 return True
             except ProviderError:
-                continue
-        return False
+                return False
+
+    def validate_model(self) -> bool:
+        """Validate that the configured model exists when the endpoint exposes a model list."""
+        if not self.model_name:
+            raise ProviderConfigurationError("provider model is not configured")
+        names = self.list_models()
+        return not names or self.model_name in names
 
     def chat(self, prompt: str) -> str:
+        if not self.model_name:
+            raise ProviderConfigurationError("provider model is not configured")
         payload = {
             "model": self.model_name,
             "messages": [{"role": "user", "content": prompt}],
@@ -62,4 +101,7 @@ class OpenAICompatibleAdapter(ProviderAdapter):
         if not choices:
             raise ProviderRequestError("provider returned no choices")
         message = choices[0].get("message") or {}
-        return str(message.get("content", ""))
+        content = message.get("content")
+        if content is None:
+            raise ProviderRequestError("provider returned an invalid message")
+        return str(content)

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -32,11 +32,18 @@ class ProviderManager:
     def _configured_models(self):
         models = {m.get("name"): m for m in self.models.list() if m.get("name")}
         if CF_ACCOUNT_ID and CF_API_TOKEN and CF_MODEL and "cloudflare" not in models:
-            models["cloudflare"] = {"name": "cloudflare", "type": "cloudflare", "model": CF_MODEL, "account_id": CF_ACCOUNT_ID, "api_token": CF_API_TOKEN}
+            models["cloudflare"] = {
+                "name": "cloudflare",
+                "type": "cloudflare",
+                "model": CF_MODEL,
+                "account_id": CF_ACCOUNT_ID,
+                "api_token": CF_API_TOKEN,
+            }
         return models
 
     def _adapter(self, model):
-        return create_adapter(model)
+        """Resolve environment-backed secrets only for the in-memory adapter."""
+        return create_adapter(ModelManager.resolve_secrets(model))
 
     def health(self, name=None):
         model = self.models.get(name) if name else self.models.default()
@@ -69,8 +76,17 @@ class ProviderManager:
         try:
             result = router.run(primary, lambda model: self._ask_model(model, prompt))
         except RoutingError as exc:
-            self.last_routing = {"selected": None, "attempts": [a.__dict__ for a in exc.attempts], "offline": offline, "error": exc.kind}
+            self.last_routing = {
+                "selected": None,
+                "attempts": [a.__dict__ for a in exc.attempts],
+                "offline": offline,
+                "error": exc.kind,
+            }
             raise
 
-        self.last_routing = {"selected": result.selected, "attempts": [a.__dict__ for a in result.attempts], "offline": offline}
+        self.last_routing = {
+            "selected": result.selected,
+            "attempts": [a.__dict__ for a in result.attempts],
+            "offline": offline,
+        }
         return result.output

--- a/providers/ollama.py
+++ b/providers/ollama.py
@@ -6,7 +6,13 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
+from .base import (
+    ProviderAdapter,
+    ProviderAuthenticationError,
+    ProviderConfigurationError,
+    ProviderRequestError,
+    ProviderUnavailable,
+)
 
 
 class OllamaAdapter(ProviderAdapter):
@@ -25,7 +31,11 @@ class OllamaAdapter(ProviderAdapter):
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = "Bearer " + self.api_key
-        request = urllib.request.Request(self.base_url + path, data=json.dumps(payload).encode() if payload is not None else None, headers=headers)
+        request = urllib.request.Request(
+            self.base_url + path,
+            data=json.dumps(payload).encode() if payload is not None else None,
+            headers=headers,
+        )
         try:
             with urllib.request.urlopen(request, timeout=self.timeout) as response:
                 return json.loads(response.read().decode("utf-8"))
@@ -38,13 +48,32 @@ class OllamaAdapter(ProviderAdapter):
         except (json.JSONDecodeError, UnicodeDecodeError):
             raise ProviderRequestError("Ollama returned invalid JSON") from None
 
+    def list_models(self) -> list[str]:
+        data = self._request("/api/tags")
+        return [
+            str(item.get("name"))
+            for item in data.get("models", [])
+            if isinstance(item, dict) and item.get("name")
+        ]
+
     def health(self) -> bool:
         try:
-            self._request("/api/tags")
+            self.list_models()
             return True
         except Exception:
             return False
 
+    def validate_model(self) -> bool:
+        if not self.model_name:
+            raise ProviderConfigurationError("Ollama model is not configured")
+        names = self.list_models()
+        return self.model_name in names
+
     def chat(self, prompt: str) -> str:
-        data = self._request("/api/generate", {"model": self.model_name, "prompt": prompt, "stream": False})
+        if not self.model_name:
+            raise ProviderConfigurationError("Ollama model is not configured")
+        data = self._request(
+            "/api/generate",
+            {"model": self.model_name, "prompt": prompt, "stream": False},
+        )
         return str(data.get("response", ""))

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -74,6 +74,45 @@ class ModelManagerTests(unittest.TestCase):
                     with self.assertRaisesRegex(ModelValidationError, message):
                         manager.upsert(model)
 
+    def test_discovery_finds_generic_endpoint_models_without_persisting_key(self):
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ,
+            {"YASIN_BASE_URL": "https://example.invalid/v1", "YASIN_API_KEY": "SECRET"},
+            clear=False,
+        ):
+            manager = ModelManager(Path(tmp) / "models.json")
+            with patch.object(manager, "_json", return_value={"data": [{"id": "model-a"}, {"id": "model-b"}]}):
+                found = manager.discover()
+            self.assertEqual([item["model"] for item in found if item["type"] == "openai_compatible"], ["model-a", "model-b"])
+            self.assertTrue(all("api_key" not in item for item in found))
+            self.assertTrue(all(item.get("api_key_env") == "YASIN_API_KEY" for item in found if item["type"] == "openai_compatible"))
+
+    def test_discovery_finds_gemini_and_uses_env_reference(self):
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ,
+            {"GEMINI_API_KEY": "SECRET", "GEMINI_MODEL": "gemini-test"},
+            clear=False,
+        ):
+            manager = ModelManager(Path(tmp) / "models.json")
+            with patch.object(manager, "_json", return_value={"data": [{"id": "gemini-test"}]}):
+                found = manager.discover()
+            gemini = [item for item in found if item["type"] == "gemini"]
+            self.assertEqual(len(gemini), 1)
+            self.assertEqual(gemini[0]["model"], "gemini-test")
+            self.assertEqual(gemini[0]["api_key_env"], "GEMINI_API_KEY")
+            self.assertNotIn("api_key", gemini[0])
+
+    def test_discovery_finds_ollama_models(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = ModelManager(Path(tmp) / "models.json")
+            def fake_json(base, path, *, timeout=3):
+                if "11434" in base:
+                    return {"models": [{"name": "qwen"}]}
+                return None
+            with patch.object(manager, "_json", side_effect=fake_json):
+                found = manager.discover()
+            self.assertEqual([(item["type"], item["model"]) for item in found], [("ollama", "qwen")])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -50,6 +50,7 @@ class ProviderAdapterTests(unittest.TestCase):
             ({"name": "llama", "type": "llama_cpp", "base_url": "http://local", "model": "m"}, LlamaCppAdapter, True),
             ({"name": "ollama", "type": "ollama", "base_url": "http://local", "model": "m"}, OllamaAdapter, True),
             ({"name": "remote", "type": "openai_compatible", "base_url": "http://remote", "model": "m"}, OpenAICompatibleAdapter, False),
+            ({"name": "gemini", "type": "gemini", "base_url": "http://gemini/v1", "model": "gemini-2.5-flash"}, OpenAICompatibleAdapter, False),
             ({"name": "cf", "type": "cloudflare", "account_id": "a", "api_token": "t", "model": "m"}, CloudflareProvider, False),
         ]
         for model, expected_type, offline in cases:
@@ -58,10 +59,24 @@ class ProviderAdapterTests(unittest.TestCase):
                 self.assertIsInstance(adapter, expected_type)
                 self.assertIs(adapter.offline, offline)
                 self.assert_contract(adapter)
+                if model["type"] == "gemini":
+                    self.assertEqual(adapter.provider_type, "gemini")
 
     def test_factory_rejects_unknown_provider(self):
         with self.assertRaises(ProviderConfigurationError):
             create_adapter({"name": "bad", "type": "unknown"})
+
+    def test_openai_base_url_with_v1_is_not_double_prefixed(self):
+        adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote/v1", "model": "m"})
+        with patch("urllib.request.urlopen", return_value=Response({"data": [{"id": "m"}]})) as mocked:
+            self.assertEqual(adapter.list_models(), ["m"])
+        self.assertEqual(mocked.call_args.args[0].full_url, "http://remote/v1/models")
+
+    def test_openai_compatible_model_discovery_and_validation(self):
+        adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
+        with patch("urllib.request.urlopen", return_value=Response({"data": [{"id": "m"}, {"id": "other"}]})):
+            self.assertEqual(adapter.list_models(), ["m", "other"])
+            self.assertTrue(adapter.validate_model())
 
     def test_openai_compatible_chat_normalizes_response(self):
         adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
@@ -93,6 +108,12 @@ class ProviderAdapterTests(unittest.TestCase):
         self.assert_contract(adapter)
         with patch("urllib.request.urlopen", return_value=Response({"response": "ok"})):
             self.assertEqual(adapter.chat("hello"), "ok")
+
+    def test_ollama_discovery_and_validation(self):
+        adapter = OllamaAdapter({"name": "ollama", "type": "ollama", "base_url": "http://local", "model": "m"})
+        with patch("urllib.request.urlopen", return_value=Response({"models": [{"name": "m"}, {"name": "other"}]})):
+            self.assertEqual(adapter.list_models(), ["m", "other"])
+            self.assertTrue(adapter.validate_model())
 
     def test_cloudflare_contract_and_chat(self):
         adapter = CloudflareProvider({"name": "cf", "type": "cloudflare", "account_id": "a", "api_token": "t", "model": "m"})


### PR DESCRIPTION
Closes #60

- improve OpenAI-compatible endpoint/model discovery
- add Gemini via Google OpenAI-compatible API
- add Ollama model discovery/validation
- resolve environment-backed credentials only at runtime
- harden base URL handling and normalized provider errors
- add provider/discovery contract tests

Validation: source and tests are covered by the repository CI; local network execution is not available in this environment.