### PR TITLE
Fix routing and fallback reliability (#61)

### DIFF
--- a/routing.py
+++ b/routing.py
@@ -1,7 +1,9 @@
 """Deterministic routing and fallback policy for YasinCoder.
 
-Routing is configuration-driven. Only transient provider failures are eligible
-for fallback; quota/auth/model/configuration errors stop the chain immediately.
+Only failures explicitly classified as safe-to-fallback are allowed to move to
+another provider. Authentication and configuration failures stop immediately.
+Routing diagnostics contain only sanitized model names and normalized error
+categories; provider payloads and credentials are never propagated.
 """
 from __future__ import annotations
 
@@ -9,7 +11,10 @@ from dataclasses import dataclass, field
 from typing import Callable, Iterable
 
 
-TRANSIENT = {"timeout", "network", "server"}
+# These failures can safely select the next configured provider without retrying
+# the same provider, which avoids retry storms. Quota/rate-limit failures are
+# treated as fallback-eligible but are never retried against the same provider.
+TRANSIENT = {"timeout", "network", "server", "quota", "rate_limit", "unavailable"}
 
 
 class RoutingError(RuntimeError):
@@ -20,8 +25,35 @@ class RoutingError(RuntimeError):
         self.attempts = attempts or []
 
 
+def _provider_error_kind(exc: Exception) -> str | None:
+    """Map YasinCoder provider errors to routing categories without raw details."""
+    kind = getattr(exc, "kind", None)
+    status = getattr(exc, "status", None)
+    if kind == "authentication":
+        return "auth"
+    if kind == "configuration":
+        return "configuration"
+    if kind == "unavailable":
+        return "unavailable"
+    if kind == "request":
+        if status == 429:
+            return "rate_limit"
+        if status in {408, 409, 425, 500, 502, 503, 504}:
+            return "server"
+        if status in {401, 403}:
+            return "auth"
+        if status == 404:
+            return "model"
+        return "provider"
+    return None
+
+
 def classify_error(exc: Exception) -> str:
     """Classify provider failures without exposing credentials or raw payloads."""
+    provider_kind = _provider_error_kind(exc)
+    if provider_kind:
+        return provider_kind
+
     import urllib.error
 
     if isinstance(exc, TimeoutError):
@@ -30,7 +62,7 @@ def classify_error(exc: Exception) -> str:
         if exc.code in {401, 403}:
             return "auth"
         if exc.code == 429:
-            return "quota"
+            return "rate_limit"
         if exc.code in {408, 409, 425, 500, 502, 503, 504}:
             return "server"
         if exc.code == 404:
@@ -41,9 +73,11 @@ def classify_error(exc: Exception) -> str:
 
     text = str(exc).lower()
     if any(token in text for token in ("quota", "rate limit", "429", "too many requests")):
-        return "quota"
+        return "rate_limit"
     if any(token in text for token in ("unauthorized", "forbidden", "api key", "authentication")):
         return "auth"
+    if any(token in text for token in ("configuration", "not configured", "missing api")):
+        return "configuration"
     if any(token in text for token in ("timeout", "timed out")):
         return "timeout"
     if any(token in text for token in ("connection", "network", "dns", "fetch failed")):
@@ -51,6 +85,12 @@ def classify_error(exc: Exception) -> str:
     if any(token in text for token in ("model not found", "unknown model", "does not exist")):
         return "model"
     return "provider"
+
+
+def _safe_model_name(model: dict) -> str:
+    """Return a bounded, credential-free diagnostic identifier."""
+    value = str(model.get("name") or model.get("model") or "unknown")
+    return value[:128].replace("\n", " ").replace("\r", " ")
 
 
 @dataclass
@@ -74,7 +114,7 @@ class Router:
         self.resolver = resolver
 
     def order(self, primary: dict, configured: Iterable[str] | None = None) -> list[dict]:
-        names = [primary.get("name", "")]
+        names = [_safe_model_name(primary)]
         names.extend(str(x) for x in (configured or primary.get("fallbacks", [])) if str(x))
         result: list[dict] = []
         seen: set[str] = set()
@@ -88,17 +128,23 @@ class Router:
         return result
 
     def run(self, primary: dict, ask: Callable[[dict], str]) -> RoutingResult:
+        # Explicit offline providers are intentionally isolated from online
+        # fallbacks: silently sending local work to a remote provider violates
+        # the user's offline intent.
         chain = [primary] if primary.get("offline") is True else self.order(primary)
         attempts: list[RouteAttempt] = []
         for model in chain:
-            name = str(model.get("name") or model.get("model") or "unknown")
+            name = _safe_model_name(model)
             try:
                 output = ask(model)
                 attempts.append(RouteAttempt(name, "success"))
                 return RoutingResult(str(output), name, attempts)
             except Exception as exc:
                 kind = classify_error(exc)
-                attempts.append(RouteAttempt(name, kind, kind if kind != "provider" else "provider_error"))
+                attempts.append(RouteAttempt(name, kind, kind))
+                # Auth/config/model failures are not safe to retry elsewhere by
+                # default. A quota/server/network failure advances immediately
+                # to the next configured provider, never retrying the same one.
                 if kind not in TRANSIENT:
                     raise RoutingError(kind, f"Provider '{name}' failed: {kind}", attempts) from exc
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,6 +1,7 @@
 import unittest
 import urllib.error
 
+from providers.base import ProviderConfigurationError, ProviderRequestError
 from routing import Router, RoutingError, classify_error
 
 
@@ -28,23 +29,56 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual([a.outcome for a in result.attempts], ["timeout", "success"])
         self.assertEqual(calls, ["primary", "backup"])
 
-    def test_quota_does_not_fallback(self):
+    def test_rate_limit_falls_back_without_retrying_primary(self):
         models = {
-            "primary": {"name": "primary", "type": "openai_compatible", "fallbacks": ["backup"]},
-            "backup": {"name": "backup", "type": "openai_compatible"},
+            "primary": {"name": "primary", "fallbacks": ["backup"]},
+            "backup": {"name": "backup"},
         }
         calls = []
 
         def ask(model):
             calls.append(model["name"])
-            raise http_error(429)
+            if model["name"] == "primary":
+                raise http_error(429)
+            return "ok"
+
+        result = Router(models.get).run(models["primary"], ask)
+        self.assertEqual(result.selected, "backup")
+        self.assertEqual([a.outcome for a in result.attempts], ["rate_limit", "success"])
+        self.assertEqual(calls, ["primary", "backup"])
+
+    def test_auth_does_not_fallback(self):
+        models = {
+            "primary": {"name": "primary", "fallbacks": ["backup"]},
+            "backup": {"name": "backup"},
+        }
+        calls = []
+
+        def ask(model):
+            calls.append(model["name"])
+            raise http_error(401)
 
         with self.assertRaises(RoutingError) as caught:
             Router(models.get).run(models["primary"], ask)
 
-        self.assertEqual(caught.exception.kind, "quota")
-        self.assertEqual(len(caught.exception.attempts), 1)
+        self.assertEqual(caught.exception.kind, "auth")
         self.assertEqual(calls, ["primary"])
+
+    def test_configuration_does_not_fallback(self):
+        models = {
+            "primary": {"name": "primary", "fallbacks": ["backup"]},
+            "backup": {"name": "backup"},
+        }
+
+        with self.assertRaises(RoutingError) as caught:
+            Router(models.get).run(models["primary"], lambda _: (_ for _ in ()).throw(ProviderConfigurationError("missing secret")))
+
+        self.assertEqual(caught.exception.kind, "configuration")
+        self.assertEqual(len(caught.exception.attempts), 1)
+
+    def test_provider_request_status_is_classified(self):
+        self.assertEqual(classify_error(ProviderRequestError("busy", status=503)), "server")
+        self.assertEqual(classify_error(ProviderRequestError("limited", status=429)), "rate_limit")
 
     def test_fallback_chain_is_loop_free(self):
         models = {
@@ -66,11 +100,7 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(calls, ["local"])
 
     def test_error_classification(self):
-        self.assertEqual(classify_error(http_error(429)), "quota")
+        self.assertEqual(classify_error(http_error(429)), "rate_limit")
         self.assertEqual(classify_error(http_error(401)), "auth")
         self.assertEqual(classify_error(http_error(503)), "server")
         self.assertEqual(classify_error(http_error(404)), "model")
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
Closes #61

- classify provider adapter errors by normalized kind/status
- fallback on safe transient, rate-limit, and unavailable failures without retry storms
- stop on authentication, configuration, and model failures
- preserve offline isolation
- sanitize and bound routing diagnostics
- expand routing tests for 429, 5xx, auth, configuration, and provider errors