### PR TITLE
[P1] Add streaming chat support end-to-end

### DIFF
--- a/gateway.py
+++ b/gateway.py
@@ -1,225 +1,125 @@
-"""Provider-neutral HTTP gateway for YasinCoder with a static PWA shell."""
+"""Provider-neutral HTTP gateway for YasinCoder with streaming support."""
 from __future__ import annotations
-
-import json
-import mimetypes
-import time
+import json, mimetypes, time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
-
+from typing import Any, Iterator
 from core.gateway_contract import chat_response, error_response, validate_chat_request
 from providers.manager import ProviderManager
 from routing import RoutingError
 from security import DEFAULT_SECURITY_POLICY, SecurityPolicy
-
 WEB_ROOT = Path(__file__).resolve().parent / "web"
 
-
 class GatewayError(Exception):
-    def __init__(self, code: str, message: str, status: int = 400):
-        super().__init__(message)
-        self.code, self.message, self.status = code, message, status
-
+    def __init__(self, code: str, message: str, status: int = 400): super().__init__(message); self.code, self.message, self.status = code, message, status
 
 class Gateway:
-    def __init__(self, manager: ProviderManager | None = None):
-        self.manager = manager or ProviderManager()
-
+    def __init__(self, manager: ProviderManager | None = None): self.manager = manager or ProviderManager()
     def models(self) -> list[dict[str, Any]]:
-        return [
-            {
-                "id": m.get("name") or m.get("model"),
-                "name": m.get("name") or m.get("model"),
-                "provider": m.get("type", "unknown"),
-                "capabilities": m.get("capabilities", ["chat"]),
-                "default": m.get("default", False),
-            }
-            for m in self.manager.list_models()
-        ]
-
-    def routing(self) -> dict[str, Any]:
-        return dict(self.manager.last_routing)
-
-    def chat(self, payload: dict[str, Any]) -> dict[str, Any]:
-        try:
-            requested, messages = validate_chat_request(payload)
-        except ValueError as exc:
-            raise GatewayError("invalid_request", str(exc)) from exc
-
-        text = "\n".join(
-            str(m.get("content", "")) for m in messages if isinstance(m, dict)
-        )
-        if not text.strip():
-            raise GatewayError("invalid_request", "messages contain no text content")
-
+        return [{"id": m.get("name") or m.get("model"), "name": m.get("name") or m.get("model"), "provider": m.get("type", "unknown"), "capabilities": m.get("capabilities", ["chat"]), "default": m.get("default", False)} for m in self.manager.list_models()]
+    def routing(self): return dict(self.manager.last_routing)
+    def _text(self, payload):
+        try: requested, messages = validate_chat_request(payload)
+        except ValueError as exc: raise GatewayError("invalid_request", str(exc)) from exc
+        text = "\n".join(str(m.get("content", "")) for m in messages if isinstance(m, dict))
+        if not text.strip(): raise GatewayError("invalid_request", "messages contain no text content")
         model = self.manager.models.get(requested) if requested else self.manager.models.default()
-        if requested and not model:
-            raise GatewayError("model_not_found", f"Model '{requested}' is not configured", 404)
-
-        try:
-            output = self.manager.ask(text, model_name=requested)
+        if requested and not model: raise GatewayError("model_not_found", f"Model '{requested}' is not configured", 404)
+        return requested, text, model
+    def chat(self, payload):
+        requested, text, model = self._text(payload)
+        try: output = self.manager.ask(text, model_name=requested)
         except RoutingError as exc:
-            status = {
-                "auth": 401,
-                "quota": 429,
-                "timeout": 503,
-                "network": 503,
-                "server": 503,
-            }.get(exc.kind, 502)
+            status = {"auth": 401, "quota": 429, "rate_limit": 429, "timeout": 503, "network": 503, "server": 503}.get(exc.kind, 502)
             raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", status) from exc
-        except Exception as exc:
-            raise GatewayError("provider_error", "Configured provider failed", 502) from exc
-
-        return chat_response(
-            request_id=f"yasin-{int(time.time() * 1000)}",
-            model=(model or {}).get("name") or requested or "auto",
-            content=str(output),
-            created=int(time.time()),
-            routing=self.routing(),
-        )
-
+        except Exception as exc: raise GatewayError("provider_error", "Configured provider failed", 502) from exc
+        return chat_response(request_id=f"yasin-{int(time.time() * 1000)}", model=(model or {}).get("name") or requested or "auto", content=str(output), created=int(time.time()), routing=self.routing())
+    def stream(self, payload) -> Iterator[dict[str, Any]]:
+        requested, text, model = self._text(payload)
+        model_name = (model or {}).get("name") or requested or "auto"
+        created = int(time.time()); request_id = f"yasin-{int(time.time() * 1000)}"
+        try:
+            for selected, chunk in self.manager.stream(text, model_name=requested):
+                yield {"id": request_id, "object": "chat.completion.chunk", "created": created, "model": selected or model_name, "choices": [{"index": 0, "delta": {"content": chunk}, "finish_reason": None}]}
+            yield {"id": request_id, "object": "chat.completion.chunk", "created": created, "model": self.manager.routing().get("selected") or model_name, "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}
+        except RoutingError as exc:
+            status = {"auth": 401, "quota": 429, "rate_limit": 429, "timeout": 503, "network": 503, "server": 503}.get(exc.kind, 502)
+            raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", status) from exc
+        except Exception as exc: raise GatewayError("provider_error", "Configured provider failed", 502) from exc
 
 class Handler(BaseHTTPRequestHandler):
     gateway: Gateway | None = None
     security: SecurityPolicy = DEFAULT_SECURITY_POLICY
     server_version = "YasinCoderGateway/1.0"
-
-    def _send(self, status: int, data: dict[str, Any]) -> None:
-        body = json.dumps(data, ensure_ascii=False).encode()
-        self.send_response(status)
-        for key, value in self.security.public_headers(self.headers.get("Origin")).items():
-            self.send_header(key, value)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Cache-Control", "no-store")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def _origin_allowed(self) -> bool:
-        origin = self.headers.get("Origin")
-        if self.security.origin_allowed(origin):
-            return True
-        self._send(403, error_response("origin_forbidden", "Origin is not allowed"))
-        return False
-
-    def _authorized(self) -> bool:
-        if not self._origin_allowed():
-            return False
+    def _send(self, status, data):
+        body = json.dumps(data, ensure_ascii=False).encode(); self.send_response(status)
+        for key, value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key, value)
+        self.send_header("Content-Type", "application/json; charset=utf-8"); self.send_header("Cache-Control", "no-store"); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
+    def _origin_allowed(self):
+        if self.security.origin_allowed(self.headers.get("Origin")): return True
+        self._send(403, error_response("origin_forbidden", "Origin is not allowed")); return False
+    def _authorized(self):
+        if not self._origin_allowed(): return False
         token = self.headers.get("Authorization", "").removeprefix("Bearer ").strip()
-        if not self.security.authenticate(token):
-            self._send(401, error_response("unauthorized", "Authentication required"))
-            return False
+        if not self.security.authenticate(token): self._send(401, error_response("unauthorized", "Authentication required")); return False
         return True
-
-    def _static(self) -> bool:
+    def _static(self):
         path = self.path.split("?", 1)[0]
-        if path in ("/", "/web", "/web/"):
-            path = "/web/index.html"
-        if not path.startswith("/web/"):
-            return False
+        if path in ("/", "/web", "/web/"): path = "/web/index.html"
+        if not path.startswith("/web/"): return False
         target = (WEB_ROOT / path.removeprefix("/web/")).resolve()
-        if WEB_ROOT not in target.parents and target != WEB_ROOT:
-            return False
-        if not target.is_file():
-            return False
-        body = target.read_bytes()
-        ctype = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
-        self.send_response(200)
-        for key, value in self.security.public_headers(self.headers.get("Origin")).items():
-            self.send_header(key, value)
-        self.send_header("Content-Type", ctype)
-        self.send_header("Cache-Control", "no-store")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-        return True
-
-    def do_OPTIONS(self) -> None:
-        if not self._origin_allowed():
-            return
+        if WEB_ROOT not in target.parents and target != WEB_ROOT or not target.is_file(): return False
+        body = target.read_bytes(); ctype = mimetypes.guess_type(target.name)[0] or "application/octet-stream"; self.send_response(200)
+        for key, value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key, value)
+        self.send_header("Content-Type", ctype); self.send_header("Cache-Control", "no-store"); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body); return True
+    def do_OPTIONS(self):
+        if not self._origin_allowed(): return
         self.send_response(204)
-        for key, value in self.security.public_headers(self.headers.get("Origin")).items():
-            self.send_header(key, value)
-        self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Max-Age", "600")
-        self.end_headers()
-
-    def do_GET(self) -> None:
-        if self._static():
-            return
+        for key, value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key, value)
+        self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type"); self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS"); self.send_header("Access-Control-Max-Age", "600"); self.end_headers()
+    def do_GET(self):
+        if self._static(): return
         if self.path in ("/health", "/api/status"):
-            if not self._origin_allowed():
-                return
-            self._send(
-                200,
-                {
-                    "ok": True,
-                    "service": "yasin-coder-gateway",
-                    "routing": self.gateway.routing(),
-                },
-            )
-            return
-        if not self._authorized():
-            return
-        if self.path in ("/api/routing", "/v1/routing"):
-            self._send(200, {"ok": True, "routing": self.gateway.routing()})
-            return
+            if not self._origin_allowed(): return
+            self._send(200, {"ok": True, "service": "yasin-coder-gateway", "routing": self.gateway.routing()}); return
+        if not self._authorized(): return
+        if self.path in ("/api/routing", "/v1/routing"): self._send(200, {"ok": True, "routing": self.gateway.routing()}); return
         if self.path in ("/v1/models", "/api/models"):
-            try:
-                self._send(200, {"object": "list", "data": self.gateway.models()})
-            except Exception:
-                self._send(500, error_response("internal_error", "Unable to list models"))
+            try: self._send(200, {"object": "list", "data": self.gateway.models()})
+            except Exception: self._send(500, error_response("internal_error", "Unable to list models"))
             return
         self._send(404, error_response("not_found", "Route not found"))
-
-    def do_POST(self) -> None:
-        if not self._authorized():
-            return
+    def do_POST(self):
+        if not self._authorized(): return
         try:
             length = int(self.headers.get("Content-Length", "0"))
-            if length < 0 or length > self.security.max_body_bytes:
-                self._send(413, error_response("payload_too_large", "Request body is too large"))
-                return
+            if length < 0 or length > self.security.max_body_bytes: self._send(413, error_response("payload_too_large", "Request body is too large")); return
             payload = json.loads(self.rfile.read(length) or b"{}")
-            if not isinstance(payload, dict):
-                self._send(400, error_response("invalid_json", "Request body must be a JSON object"))
-                return
-        except (ValueError, json.JSONDecodeError):
-            self._send(400, error_response("invalid_json", "Request body must be JSON"))
-            return
-
-        if self.path in ("/v1/chat/completions", "/api/chat"):
+            if not isinstance(payload, dict): self._send(400, error_response("invalid_json", "Request body must be a JSON object")); return
+        except (ValueError, json.JSONDecodeError): self._send(400, error_response("invalid_json", "Request body must be JSON")); return
+        if self.path not in ("/v1/chat/completions", "/api/chat"): self._send(404, error_response("not_found", "Route not found")); return
+        if payload.get("stream") is True:
             try:
-                self._send(200, self.gateway.chat(payload))
+                self.send_response(200)
+                for key, value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key, value)
+                self.send_header("Content-Type", "text/event-stream; charset=utf-8"); self.send_header("Cache-Control", "no-cache, no-store"); self.send_header("Connection", "keep-alive"); self.end_headers()
+                for event in self.gateway.stream(payload):
+                    self.wfile.write(("data: " + json.dumps(event, ensure_ascii=False) + "\n\n").encode()); self.wfile.flush()
+                self.wfile.write(b"data: [DONE]\n\n"); self.wfile.flush()
             except GatewayError as exc:
-                self._send(exc.status, error_response(exc.code, exc.message))
-            except Exception:
-                self._send(500, error_response("internal_error", "Gateway request failed"))
+                try: self.wfile.write(("data: " + json.dumps(error_response(exc.code, exc.message)) + "\n\n").encode()); self.wfile.flush()
+                except OSError: pass
+            except (BrokenPipeError, ConnectionResetError): pass
             return
-        self._send(404, error_response("not_found", "Route not found"))
+        try: self._send(200, self.gateway.chat(payload))
+        except GatewayError as exc: self._send(exc.status, error_response(exc.code, exc.message))
+        except Exception: self._send(500, error_response("internal_error", "Gateway request failed"))
+    def log_message(self, format: str, *args: Any): return
 
-    def log_message(self, format: str, *args: Any) -> None:
-        return
+def create_server(host="127.0.0.1", port=18765, manager=None, security=None):
+    Handler.gateway = Gateway(manager); Handler.security = security or SecurityPolicy.from_env(); return ThreadingHTTPServer((host, port), Handler)
 
+def main():
+    server = create_server(); print(f"YasinCoder gateway listening on http://{server.server_address[0]}:{server.server_address[1]}"); server.serve_forever()
 
-def create_server(
-    host: str = "127.0.0.1",
-    port: int = 18765,
-    manager: ProviderManager | None = None,
-    security: SecurityPolicy | None = None,
-):
-    Handler.gateway = Gateway(manager)
-    Handler.security = security or SecurityPolicy.from_env()
-    return ThreadingHTTPServer((host, port), Handler)
-
-
-def main() -> None:
-    server = create_server()
-    print(f"YasinCoder gateway listening on http://{server.server_address[0]}:{server.server_address[1]}")
-    server.serve_forever()
-
-
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__": main()

--- a/gateway.py
+++ b/gateway.py
@@ -9,14 +9,11 @@ from providers.manager import ProviderManager
 from routing import RoutingError
 from security import DEFAULT_SECURITY_POLICY, SecurityPolicy
 WEB_ROOT = Path(__file__).resolve().parent / "web"
-
 class GatewayError(Exception):
-    def __init__(self, code: str, message: str, status: int = 400): super().__init__(message); self.code, self.message, self.status = code, message, status
-
+    def __init__(self, code, message, status=400): super().__init__(message); self.code, self.message, self.status = code, message, status
 class Gateway:
-    def __init__(self, manager: ProviderManager | None = None): self.manager = manager or ProviderManager()
-    def models(self) -> list[dict[str, Any]]:
-        return [{"id": m.get("name") or m.get("model"), "name": m.get("name") or m.get("model"), "provider": m.get("type", "unknown"), "capabilities": m.get("capabilities", ["chat"]), "default": m.get("default", False)} for m in self.manager.list_models()]
+    def __init__(self, manager=None): self.manager = manager or ProviderManager()
+    def models(self): return [{"id": m.get("name") or m.get("model"), "name": m.get("name") or m.get("model"), "provider": m.get("type", "unknown"), "capabilities": m.get("capabilities", ["chat"]), "default": m.get("default", False)} for m in self.manager.list_models()]
     def routing(self): return dict(self.manager.last_routing)
     def _text(self, payload):
         try: requested, messages = validate_chat_request(payload)
@@ -29,97 +26,83 @@ class Gateway:
     def chat(self, payload):
         requested, text, model = self._text(payload)
         try: output = self.manager.ask(text, model_name=requested)
-        except RoutingError as exc:
-            status = {"auth": 401, "quota": 429, "rate_limit": 429, "timeout": 503, "network": 503, "server": 503}.get(exc.kind, 502)
-            raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", status) from exc
-        except Exception as exc: raise GatewayError("provider_error", "Configured provider failed", 502) from exc
-        return chat_response(request_id=f"yasin-{int(time.time() * 1000)}", model=(model or {}).get("name") or requested or "auto", content=str(output), created=int(time.time()), routing=self.routing())
-    def stream(self, payload) -> Iterator[dict[str, Any]]:
-        requested, text, model = self._text(payload)
-        model_name = (model or {}).get("name") or requested or "auto"
-        created = int(time.time()); request_id = f"yasin-{int(time.time() * 1000)}"
+        except RoutingError as exc: raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", {"auth":401,"quota":429,"rate_limit":429,"timeout":503,"network":503,"server":503}.get(exc.kind, 502)) from exc
+        except Exception: raise GatewayError("provider_error", "Configured provider failed", 502)
+        return chat_response(request_id=f"yasin-{int(time.time()*1000)}", model=(model or {}).get("name") or requested or "auto", content=str(output), created=int(time.time()), routing=self.routing())
+    def stream(self, payload) -> Iterator[dict]:
+        requested, text, model = self._text(payload); model_name = (model or {}).get("name") or requested or "auto"; created = int(time.time()); request_id = f"yasin-{int(time.time()*1000)}"
         try:
             for selected, chunk in self.manager.stream(text, model_name=requested):
                 yield {"id": request_id, "object": "chat.completion.chunk", "created": created, "model": selected or model_name, "choices": [{"index": 0, "delta": {"content": chunk}, "finish_reason": None}]}
             yield {"id": request_id, "object": "chat.completion.chunk", "created": created, "model": self.manager.routing().get("selected") or model_name, "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}
-        except RoutingError as exc:
-            status = {"auth": 401, "quota": 429, "rate_limit": 429, "timeout": 503, "network": 503, "server": 503}.get(exc.kind, 502)
-            raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", status) from exc
-        except Exception as exc: raise GatewayError("provider_error", "Configured provider failed", 502) from exc
-
+        except RoutingError as exc: raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", {"auth":401,"quota":429,"rate_limit":429,"timeout":503,"network":503,"server":503}.get(exc.kind, 502)) from exc
+        except Exception: raise GatewayError("provider_error", "Configured provider failed", 502)
 class Handler(BaseHTTPRequestHandler):
-    gateway: Gateway | None = None
-    security: SecurityPolicy = DEFAULT_SECURITY_POLICY
-    server_version = "YasinCoderGateway/1.0"
+    gateway=None; security=DEFAULT_SECURITY_POLICY; server_version="YasinCoderGateway/1.0"
     def _send(self, status, data):
-        body = json.dumps(data, ensure_ascii=False).encode(); self.send_response(status)
-        for key, value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key, value)
-        self.send_header("Content-Type", "application/json; charset=utf-8"); self.send_header("Cache-Control", "no-store"); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
+        body=json.dumps(data,ensure_ascii=False).encode(); self.send_response(status)
+        for key,value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key,value)
+        self.send_header("Content-Type","application/json; charset=utf-8"); self.send_header("Cache-Control","no-store"); self.send_header("Content-Length",str(len(body))); self.end_headers(); self.wfile.write(body)
     def _origin_allowed(self):
         if self.security.origin_allowed(self.headers.get("Origin")): return True
-        self._send(403, error_response("origin_forbidden", "Origin is not allowed")); return False
+        self._send(403,error_response("origin_forbidden","Origin is not allowed")); return False
     def _authorized(self):
         if not self._origin_allowed(): return False
-        token = self.headers.get("Authorization", "").removeprefix("Bearer ").strip()
-        if not self.security.authenticate(token): self._send(401, error_response("unauthorized", "Authentication required")); return False
+        token=self.headers.get("Authorization","").removeprefix("Bearer ").strip()
+        if not self.security.authenticate(token): self._send(401,error_response("unauthorized","Authentication required")); return False
         return True
     def _static(self):
-        path = self.path.split("?", 1)[0]
-        if path in ("/", "/web", "/web/"): path = "/web/index.html"
+        path=self.path.split("?",1)[0]
+        if path in ("/","/web","/web/"): path="/web/index.html"
         if not path.startswith("/web/"): return False
-        target = (WEB_ROOT / path.removeprefix("/web/")).resolve()
-        if WEB_ROOT not in target.parents and target != WEB_ROOT or not target.is_file(): return False
-        body = target.read_bytes(); ctype = mimetypes.guess_type(target.name)[0] or "application/octet-stream"; self.send_response(200)
-        for key, value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key, value)
-        self.send_header("Content-Type", ctype); self.send_header("Cache-Control", "no-store"); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body); return True
+        target=(WEB_ROOT/path.removeprefix("/web/")).resolve()
+        if WEB_ROOT not in target.parents and target!=WEB_ROOT or not target.is_file(): return False
+        body=target.read_bytes(); ctype=mimetypes.guess_type(target.name)[0] or "application/octet-stream"; self.send_response(200)
+        for key,value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key,value)
+        self.send_header("Content-Type",ctype); self.send_header("Cache-Control","no-store"); self.send_header("Content-Length",str(len(body))); self.end_headers(); self.wfile.write(body); return True
     def do_OPTIONS(self):
         if not self._origin_allowed(): return
         self.send_response(204)
-        for key, value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key, value)
-        self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type"); self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS"); self.send_header("Access-Control-Max-Age", "600"); self.end_headers()
+        for key,value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key,value)
+        self.send_header("Access-Control-Allow-Headers","Authorization, Content-Type"); self.send_header("Access-Control-Allow-Methods","GET, POST, OPTIONS"); self.send_header("Access-Control-Max-Age","600"); self.end_headers()
     def do_GET(self):
         if self._static(): return
-        if self.path in ("/health", "/api/status"):
+        if self.path in ("/health","/api/status"):
             if not self._origin_allowed(): return
-            self._send(200, {"ok": True, "service": "yasin-coder-gateway", "routing": self.gateway.routing()}); return
+            self._send(200,{"ok":True,"service":"yasin-coder-gateway","routing":self.gateway.routing()}); return
         if not self._authorized(): return
-        if self.path in ("/api/routing", "/v1/routing"): self._send(200, {"ok": True, "routing": self.gateway.routing()}); return
-        if self.path in ("/v1/models", "/api/models"):
-            try: self._send(200, {"object": "list", "data": self.gateway.models()})
-            except Exception: self._send(500, error_response("internal_error", "Unable to list models"))
+        if self.path in ("/api/routing","/v1/routing"): self._send(200,{"ok":True,"routing":self.gateway.routing()}); return
+        if self.path in ("/v1/models","/api/models"):
+            try:self._send(200,{"object":"list","data":self.gateway.models()})
+            except Exception:self._send(500,error_response("internal_error","Unable to list models"))
             return
-        self._send(404, error_response("not_found", "Route not found"))
+        self._send(404,error_response("not_found","Route not found"))
     def do_POST(self):
         if not self._authorized(): return
         try:
-            length = int(self.headers.get("Content-Length", "0"))
-            if length < 0 or length > self.security.max_body_bytes: self._send(413, error_response("payload_too_large", "Request body is too large")); return
-            payload = json.loads(self.rfile.read(length) or b"{}")
-            if not isinstance(payload, dict): self._send(400, error_response("invalid_json", "Request body must be a JSON object")); return
-        except (ValueError, json.JSONDecodeError): self._send(400, error_response("invalid_json", "Request body must be JSON")); return
-        if self.path not in ("/v1/chat/completions", "/api/chat"): self._send(404, error_response("not_found", "Route not found")); return
+            length=int(self.headers.get("Content-Length","0"))
+            if length<0 or length>self.security.max_body_bytes: self._send(413,error_response("payload_too_large","Request body is too large")); return
+            payload=json.loads(self.rfile.read(length) or b"{}")
+            if not isinstance(payload,dict): self._send(400,error_response("invalid_json","Request body must be a JSON object")); return
+        except (ValueError,json.JSONDecodeError): self._send(400,error_response("invalid_json","Request body must be JSON")); return
+        if self.path not in ("/v1/chat/completions","/api/chat"): self._send(404,error_response("not_found","Route not found")); return
         if payload.get("stream") is True:
             try:
                 self.send_response(200)
-                for key, value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key, value)
-                self.send_header("Content-Type", "text/event-stream; charset=utf-8"); self.send_header("Cache-Control", "no-cache, no-store"); self.send_header("Connection", "keep-alive"); self.end_headers()
-                for event in self.gateway.stream(payload):
-                    self.wfile.write(("data: " + json.dumps(event, ensure_ascii=False) + "\n\n").encode()); self.wfile.flush()
+                for key,value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key,value)
+                self.send_header("Content-Type","text/event-stream; charset=utf-8"); self.send_header("Cache-Control","no-cache, no-store"); self.end_headers()
+                for event in self.gateway.stream(payload): self.wfile.write(("data: "+json.dumps(event,ensure_ascii=False)+"\n\n").encode()); self.wfile.flush()
                 self.wfile.write(b"data: [DONE]\n\n"); self.wfile.flush()
             except GatewayError as exc:
-                try: self.wfile.write(("data: " + json.dumps(error_response(exc.code, exc.message)) + "\n\n").encode()); self.wfile.flush()
+                try:self.wfile.write(("data: "+json.dumps(error_response(exc.code,exc.message))+"\n\n").encode()); self.wfile.flush()
                 except OSError: pass
-            except (BrokenPipeError, ConnectionResetError): pass
+            except (BrokenPipeError,ConnectionResetError): pass
             return
-        try: self._send(200, self.gateway.chat(payload))
-        except GatewayError as exc: self._send(exc.status, error_response(exc.code, exc.message))
-        except Exception: self._send(500, error_response("internal_error", "Gateway request failed"))
-    def log_message(self, format: str, *args: Any): return
-
-def create_server(host="127.0.0.1", port=18765, manager=None, security=None):
-    Handler.gateway = Gateway(manager); Handler.security = security or SecurityPolicy.from_env(); return ThreadingHTTPServer((host, port), Handler)
-
+        try:self._send(200,self.gateway.chat(payload))
+        except GatewayError as exc:self._send(exc.status,error_response(exc.code,exc.message))
+        except Exception:self._send(500,error_response("internal_error","Gateway request failed"))
+    def log_message(self,format,*args): return
+def create_server(host="127.0.0.1",port=18765,manager=None,security=None): Handler.gateway=Gateway(manager); Handler.security=security or SecurityPolicy.from_env(); return ThreadingHTTPServer((host,port),Handler)
 def main():
-    server = create_server(); print(f"YasinCoder gateway listening on http://{server.server_address[0]}:{server.server_address[1]}"); server.serve_forever()
-
-if __name__ == "__main__": main()
+    server=create_server(); print(f"YasinCoder gateway listening on http://{server.server_address[0]}:{server.server_address[1]}"); server.serve_forever()
+if __name__=="__main__": main()

--- a/gateway.py
+++ b/gateway.py
@@ -3,43 +3,44 @@ from __future__ import annotations
 import json, mimetypes, time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Iterator
 from core.gateway_contract import chat_response, error_response, validate_chat_request
 from providers.manager import ProviderManager
 from routing import RoutingError
 from security import DEFAULT_SECURITY_POLICY, SecurityPolicy
-WEB_ROOT = Path(__file__).resolve().parent / "web"
+WEB_ROOT=Path(__file__).resolve().parent/"web"
 class GatewayError(Exception):
-    def __init__(self, code, message, status=400): super().__init__(message); self.code, self.message, self.status = code, message, status
+    def __init__(self,code,message,status=400): super().__init__(message); self.code,self.message,self.status=code,message,status
 class Gateway:
-    def __init__(self, manager=None): self.manager = manager or ProviderManager()
-    def models(self): return [{"id": m.get("name") or m.get("model"), "name": m.get("name") or m.get("model"), "provider": m.get("type", "unknown"), "capabilities": m.get("capabilities", ["chat"]), "default": m.get("default", False)} for m in self.manager.list_models()]
+    def __init__(self,manager=None): self.manager=manager or ProviderManager()
+    def models(self): return [{"id":m.get("name") or m.get("model"),"name":m.get("name") or m.get("model"),"provider":m.get("type","unknown"),"capabilities":m.get("capabilities",["chat"]),"default":m.get("default",False)} for m in self.manager.list_models()]
     def routing(self): return dict(self.manager.last_routing)
-    def _text(self, payload):
-        try: requested, messages = validate_chat_request(payload)
-        except ValueError as exc: raise GatewayError("invalid_request", str(exc)) from exc
-        text = "\n".join(str(m.get("content", "")) for m in messages if isinstance(m, dict))
-        if not text.strip(): raise GatewayError("invalid_request", "messages contain no text content")
-        model = self.manager.models.get(requested) if requested else self.manager.models.default()
-        if requested and not model: raise GatewayError("model_not_found", f"Model '{requested}' is not configured", 404)
-        return requested, text, model
-    def chat(self, payload):
-        requested, text, model = self._text(payload)
-        try: output = self.manager.ask(text, model_name=requested)
-        except RoutingError as exc: raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", {"auth":401,"quota":429,"rate_limit":429,"timeout":503,"network":503,"server":503}.get(exc.kind, 502)) from exc
-        except Exception: raise GatewayError("provider_error", "Configured provider failed", 502)
-        return chat_response(request_id=f"yasin-{int(time.time()*1000)}", model=(model or {}).get("name") or requested or "auto", content=str(output), created=int(time.time()), routing=self.routing())
-    def stream(self, payload) -> Iterator[dict]:
-        requested, text, model = self._text(payload); model_name = (model or {}).get("name") or requested or "auto"; created = int(time.time()); request_id = f"yasin-{int(time.time()*1000)}"
+    def _text(self,payload):
+        try: requested,messages=validate_chat_request(payload)
+        except ValueError as exc: raise GatewayError("invalid_request",str(exc)) from exc
+        text="\n".join(str(m.get("content","")) for m in messages if isinstance(m,dict))
+        if not text.strip(): raise GatewayError("invalid_request","messages contain no text content")
+        model=self.manager.models.get(requested) if requested else self.manager.models.default()
+        if requested and not model: raise GatewayError("model_not_found",f"Model '{requested}' is not configured",404)
+        return requested,text,model
+    def chat(self,payload):
+        requested,text,model=self._text(payload)
+        try: output=self.manager.ask(text,model_name=requested)
+        except RoutingError as exc: raise GatewayError(f"provider_{exc.kind}",f"Provider routing failed: {exc.kind}",{"auth":401,"quota":429,"rate_limit":429,"timeout":503,"network":503,"server":503}.get(exc.kind,502)) from exc
+        except Exception: raise GatewayError("provider_error","Configured provider failed",502)
+        return chat_response(request_id=f"yasin-{int(time.time()*1000)}",model=(model or {}).get("name") or requested or "auto",content=str(output),created=int(time.time()),routing=self.routing())
+    def stream(self,payload)->Iterator[dict]:
+        requested,text,model=self._text(payload); model_name=(model or {}).get("name") or requested or "auto"; created=int(time.time()); request_id=f"yasin-{int(time.time()*1000)}"
         try:
-            for selected, chunk in self.manager.stream(text, model_name=requested):
-                yield {"id": request_id, "object": "chat.completion.chunk", "created": created, "model": selected or model_name, "choices": [{"index": 0, "delta": {"content": chunk}, "finish_reason": None}]}
-            yield {"id": request_id, "object": "chat.completion.chunk", "created": created, "model": self.manager.routing().get("selected") or model_name, "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}
-        except RoutingError as exc: raise GatewayError(f"provider_{exc.kind}", f"Provider routing failed: {exc.kind}", {"auth":401,"quota":429,"rate_limit":429,"timeout":503,"network":503,"server":503}.get(exc.kind, 502)) from exc
-        except Exception: raise GatewayError("provider_error", "Configured provider failed", 502)
+            for selected,chunk in self.manager.stream(text,model_name=requested):
+                yield {"id":request_id,"object":"chat.completion.chunk","created":created,"model":selected or model_name,"choices":[{"index":0,"delta":{"content":chunk},"finish_reason":None}]}
+            routing=self.manager.routing() if hasattr(self.manager,"routing") else getattr(self.manager,"last_routing",{})
+            yield {"id":request_id,"object":"chat.completion.chunk","created":created,"model":routing.get("selected") or model_name,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+        except RoutingError as exc: raise GatewayError(f"provider_{exc.kind}",f"Provider routing failed: {exc.kind}",{"auth":401,"quota":429,"rate_limit":429,"timeout":503,"network":503,"server":503}.get(exc.kind,502)) from exc
+        except Exception: raise GatewayError("provider_error","Configured provider failed",502)
 class Handler(BaseHTTPRequestHandler):
     gateway=None; security=DEFAULT_SECURITY_POLICY; server_version="YasinCoderGateway/1.0"
-    def _send(self, status, data):
+    def _send(self,status,data):
         body=json.dumps(data,ensure_ascii=False).encode(); self.send_response(status)
         for key,value in self.security.public_headers(self.headers.get("Origin")).items(): self.send_header(key,value)
         self.send_header("Content-Type","application/json; charset=utf-8"); self.send_header("Cache-Control","no-store"); self.send_header("Content-Length",str(len(body))); self.end_headers(); self.wfile.write(body)

--- a/providers/base.py
+++ b/providers/base.py
@@ -3,32 +3,19 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Iterator
 
 
 class ProviderError(RuntimeError):
     kind = "provider_error"
-
     def __init__(self, message: str, *, status: int | None = None):
         super().__init__(message)
         self.status = status
 
-
-class ProviderUnavailable(ProviderError):
-    kind = "unavailable"
-
-
-class ProviderAuthenticationError(ProviderError):
-    kind = "authentication"
-
-
-class ProviderConfigurationError(ProviderError):
-    kind = "configuration"
-
-
-class ProviderRequestError(ProviderError):
-    kind = "request"
-
+class ProviderUnavailable(ProviderError): kind = "unavailable"
+class ProviderAuthenticationError(ProviderError): kind = "authentication"
+class ProviderConfigurationError(ProviderError): kind = "configuration"
+class ProviderRequestError(ProviderError): kind = "request"
 
 @dataclass(frozen=True)
 class ModelInfo:
@@ -37,34 +24,25 @@ class ModelInfo:
     model: str
     offline: bool
     capabilities: tuple[str, ...] = ("chat",)
-
     def as_dict(self) -> dict[str, Any]:
         return {"name": self.name, "provider": self.provider, "model": self.model, "offline": self.offline, "capabilities": list(self.capabilities)}
-
 
 class ProviderAdapter(ABC):
     """Stable interface consumed by gateway and routing layers."""
     provider_type = "unknown"
     offline = False
-
-    def __init__(self, model: dict[str, Any]):
-        self.model = model
-
+    def __init__(self, model: dict[str, Any]): self.model = model
     @property
-    def name(self) -> str:
-        return str(self.model.get("name") or self.model.get("model") or self.provider_type)
-
+    def name(self) -> str: return str(self.model.get("name") or self.model.get("model") or self.provider_type)
     @property
-    def model_name(self) -> str:
-        return str(self.model.get("model") or self.name)
-
+    def model_name(self) -> str: return str(self.model.get("model") or self.name)
     @abstractmethod
-    def health(self) -> bool:
-        raise NotImplementedError
-
+    def health(self) -> bool: raise NotImplementedError
     @abstractmethod
-    def chat(self, prompt: str) -> str:
-        raise NotImplementedError
-
+    def chat(self, prompt: str) -> str: raise NotImplementedError
+    def stream_chat(self, prompt: str) -> Iterator[str]:
+        """Yield chunks; adapters without native streaming retain compatibility."""
+        yield self.chat(prompt)
     def info(self) -> ModelInfo:
-        return ModelInfo(self.name, self.provider_type, self.model_name, self.offline)
+        caps = ("chat", "streaming") if self.__class__.stream_chat is not ProviderAdapter.stream_chat else ("chat",)
+        return ModelInfo(self.name, self.provider_type, self.model_name, self.offline, caps)

--- a/providers/cloudflare.py
+++ b/providers/cloudflare.py
@@ -1,56 +1,46 @@
 """Cloudflare Workers AI adapter."""
 from __future__ import annotations
-import json
-import urllib.error
-import urllib.request
+import json, urllib.error, urllib.request
 from typing import Any, Iterator
 from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
-
 class CloudflareProvider(ProviderAdapter):
-    provider_type = "cloudflare"
-    offline = False
-    def __init__(self, model: dict[str, Any] | None = None):
-        super().__init__(dict(model or {}))
-        self.account_id = str(self.model.get("account_id", "")); self.api_token = str(self.model.get("api_token", ""))
-        self._model_name = str(self.model.get("model") or self.model.get("name") or ""); self.timeout = float(self.model.get("timeout", 120))
+    provider_type="cloudflare"; offline=False
+    def __init__(self, model: dict[str, Any] | None=None):
+        super().__init__(dict(model or {})); self.account_id=str(self.model.get("account_id","")); self.api_token=str(self.model.get("api_token","")); self._model_name=str(self.model.get("model") or self.model.get("name") or ""); self.timeout=float(self.model.get("timeout",120))
     @property
-    def model_name(self) -> str: return self._model_name
+    def model_name(self): return self._model_name
     @property
-    def _url(self) -> str: return f"https://api.cloudflare.com/client/v4/accounts/{self.account_id}/ai/run/{self.model_name}"
-    def health(self) -> bool: return bool(self.account_id and self.api_token and self.model_name)
-    def _open(self, stream: bool):
+    def _url(self): return f"https://api.cloudflare.com/client/v4/accounts/{self.account_id}/ai/run/{self.model_name}"
+    def health(self): return bool(self.account_id and self.api_token and self.model_name)
+    def _open(self, prompt: str, stream: bool):
         if not self.account_id or not self.api_token or not self.model_name: raise ProviderConfigurationError("Cloudflare account, token and model must be configured")
-        payload = {"messages": [{"role": "user", "content": self._prompt}], "stream": stream}
-        request = urllib.request.Request(self._url, data=json.dumps(payload).encode(), headers={"Authorization": "Bearer " + self.api_token, "Content-Type": "application/json", "Accept": "text/event-stream" if stream else "application/json"})
-        try: return urllib.request.urlopen(request, timeout=self.timeout)
+        payload={"messages":[{"role":"user","content":prompt}],"stream":stream}; request=urllib.request.Request(self._url,data=json.dumps(payload).encode(),headers={"Authorization":"Bearer "+self.api_token,"Content-Type":"application/json","Accept":"text/event-stream" if stream else "application/json"})
+        try: return urllib.request.urlopen(request,timeout=self.timeout)
         except urllib.error.HTTPError as exc:
-            if exc.code in (401, 403): raise ProviderAuthenticationError("Cloudflare authentication failed", status=exc.code) from None
-            if exc.code == 429: raise ProviderRequestError("Cloudflare rate limit", status=exc.code) from None
-            raise ProviderRequestError(f"Cloudflare returned HTTP {exc.code}", status=exc.code) from None
-        except (urllib.error.URLError, TimeoutError, OSError): raise ProviderUnavailable("Cloudflare is unavailable") from None
-    def stream_chat(self, prompt: str) -> Iterator[str]:
-        self._prompt = prompt
-        response = self._open(True)
+            if exc.code in (401,403): raise ProviderAuthenticationError("Cloudflare authentication failed",status=exc.code) from None
+            if exc.code==429: raise ProviderRequestError("Cloudflare rate limit",status=exc.code) from None
+            raise ProviderRequestError(f"Cloudflare returned HTTP {exc.code}",status=exc.code) from None
+        except (urllib.error.URLError,TimeoutError,OSError): raise ProviderUnavailable("Cloudflare is unavailable") from None
+    def stream_chat(self,prompt: str)->Iterator[str]:
+        response=self._open(prompt,True)
         try:
-            for raw in iter(response.readline, b""):
-                line = raw.decode("utf-8", "replace").strip()
+            for raw in iter(response.readline,b""):
+                line=raw.decode("utf-8","replace").strip()
                 if not line: continue
-                data = line[5:].strip() if line.startswith("data:") else line
-                if data == "[DONE]": break
-                try: event = json.loads(data)
+                data=line[5:].strip() if line.startswith("data:") else line
+                if data=="[DONE]": break
+                try: event=json.loads(data)
                 except json.JSONDecodeError: continue
-                result = event.get("result") or event
-                text = result.get("response") if isinstance(result, dict) else None
-                if text is None and isinstance(result, dict): text = result.get("output")
+                result=event.get("result") or event; text=result.get("response") if isinstance(result,dict) else None
+                if text is None and isinstance(result,dict): text=result.get("output")
                 if text: yield str(text)
-        finally: response.close()
-    def chat(self, prompt: str) -> str:
-        self._prompt = prompt
-        response = self._open(False)
-        try: data = json.loads(response.read().decode("utf-8"))
-        except (json.JSONDecodeError, UnicodeDecodeError): raise ProviderRequestError("Cloudflare returned invalid JSON") from None
-        finally: response.close()
-        result = data.get("result") or {}
+        finally: getattr(response,"close",lambda:None)()
+    def chat(self,prompt: str)->str:
+        response=self._open(prompt,False)
+        try: data=json.loads(response.read().decode("utf-8"))
+        except (json.JSONDecodeError,UnicodeDecodeError): raise ProviderRequestError("Cloudflare returned invalid JSON") from None
+        finally: getattr(response,"close",lambda:None)()
+        result=data.get("result") or {}
         if "response" in result: return str(result["response"])
         if result.get("output"): return str(result["output"])
         raise ProviderRequestError("Cloudflare returned no model output")

--- a/providers/cloudflare.py
+++ b/providers/cloudflare.py
@@ -1,53 +1,56 @@
 """Cloudflare Workers AI adapter."""
 from __future__ import annotations
-
 import json
 import urllib.error
 import urllib.request
-from typing import Any
-
+from typing import Any, Iterator
 from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
-
 
 class CloudflareProvider(ProviderAdapter):
     provider_type = "cloudflare"
     offline = False
-
     def __init__(self, model: dict[str, Any] | None = None):
-        model = dict(model or {})
-        super().__init__(model)
-        self.account_id = str(model.get("account_id", ""))
-        self.api_token = str(model.get("api_token", ""))
-        self._model_name = str(model.get("model") or model.get("name") or "")
-        self.timeout = float(model.get("timeout", 120))
-
+        super().__init__(dict(model or {}))
+        self.account_id = str(self.model.get("account_id", "")); self.api_token = str(self.model.get("api_token", ""))
+        self._model_name = str(self.model.get("model") or self.model.get("name") or ""); self.timeout = float(self.model.get("timeout", 120))
     @property
-    def model_name(self) -> str:
-        return self._model_name
-
-    def health(self) -> bool:
-        return bool(self.account_id and self.api_token and self.model_name)
-
-    def chat(self, prompt: str) -> str:
-        if not self.account_id or not self.api_token or not self.model_name:
-            raise ProviderConfigurationError("Cloudflare account, token and model must be configured")
-        url = f"https://api.cloudflare.com/client/v4/accounts/{self.account_id}/ai/run/{self.model_name}"
-        payload = {"messages": [{"role": "user", "content": prompt}]}
-        request = urllib.request.Request(url, data=json.dumps(payload).encode(), headers={"Authorization": "Bearer " + self.api_token, "Content-Type": "application/json"})
-        try:
-            with urllib.request.urlopen(request, timeout=self.timeout) as response:
-                data = json.loads(response.read().decode("utf-8"))
+    def model_name(self) -> str: return self._model_name
+    @property
+    def _url(self) -> str: return f"https://api.cloudflare.com/client/v4/accounts/{self.account_id}/ai/run/{self.model_name}"
+    def health(self) -> bool: return bool(self.account_id and self.api_token and self.model_name)
+    def _open(self, stream: bool):
+        if not self.account_id or not self.api_token or not self.model_name: raise ProviderConfigurationError("Cloudflare account, token and model must be configured")
+        payload = {"messages": [{"role": "user", "content": self._prompt}], "stream": stream}
+        request = urllib.request.Request(self._url, data=json.dumps(payload).encode(), headers={"Authorization": "Bearer " + self.api_token, "Content-Type": "application/json", "Accept": "text/event-stream" if stream else "application/json"})
+        try: return urllib.request.urlopen(request, timeout=self.timeout)
         except urllib.error.HTTPError as exc:
-            if exc.code in (401, 403):
-                raise ProviderAuthenticationError("Cloudflare authentication failed", status=exc.code) from None
+            if exc.code in (401, 403): raise ProviderAuthenticationError("Cloudflare authentication failed", status=exc.code) from None
+            if exc.code == 429: raise ProviderRequestError("Cloudflare rate limit", status=exc.code) from None
             raise ProviderRequestError(f"Cloudflare returned HTTP {exc.code}", status=exc.code) from None
-        except (urllib.error.URLError, TimeoutError, OSError):
-            raise ProviderUnavailable("Cloudflare is unavailable") from None
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            raise ProviderRequestError("Cloudflare returned invalid JSON") from None
+        except (urllib.error.URLError, TimeoutError, OSError): raise ProviderUnavailable("Cloudflare is unavailable") from None
+    def stream_chat(self, prompt: str) -> Iterator[str]:
+        self._prompt = prompt
+        response = self._open(True)
+        try:
+            for raw in iter(response.readline, b""):
+                line = raw.decode("utf-8", "replace").strip()
+                if not line: continue
+                data = line[5:].strip() if line.startswith("data:") else line
+                if data == "[DONE]": break
+                try: event = json.loads(data)
+                except json.JSONDecodeError: continue
+                result = event.get("result") or event
+                text = result.get("response") if isinstance(result, dict) else None
+                if text is None and isinstance(result, dict): text = result.get("output")
+                if text: yield str(text)
+        finally: response.close()
+    def chat(self, prompt: str) -> str:
+        self._prompt = prompt
+        response = self._open(False)
+        try: data = json.loads(response.read().decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError): raise ProviderRequestError("Cloudflare returned invalid JSON") from None
+        finally: response.close()
         result = data.get("result") or {}
-        if "response" in result:
-            return str(result["response"])
-        if result.get("output"):
-            return str(result["output"])
+        if "response" in result: return str(result["response"])
+        if result.get("output"): return str(result["output"])
         raise ProviderRequestError("Cloudflare returned no model output")

--- a/providers/http_compatible.py
+++ b/providers/http_compatible.py
@@ -4,21 +4,13 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
-from typing import Any
+from typing import Any, Iterator
 
-from .base import (
-    ProviderAdapter,
-    ProviderAuthenticationError,
-    ProviderConfigurationError,
-    ProviderError,
-    ProviderRequestError,
-    ProviderUnavailable,
-)
+from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderError, ProviderRequestError, ProviderUnavailable
 
 
 class OpenAICompatibleAdapter(ProviderAdapter):
     provider_type = "openai_compatible"
-
     def __init__(self, model: dict[str, Any], *, provider_type: str | None = None, offline: bool = False):
         super().__init__(model)
         self.provider_type = provider_type or str(model.get("provider") or self.provider_type)
@@ -26,82 +18,72 @@ class OpenAICompatibleAdapter(ProviderAdapter):
         self.base_url = str(model.get("base_url", "")).rstrip("/")
         self.api_key = str(model.get("api_key", ""))
         self.timeout = float(model.get("timeout", 120))
-
     def _url(self, path: str) -> str:
         base = self.base_url.rstrip("/")
-        if path.startswith("/v1/") and base.endswith("/v1"):
-            return base + path[3:]
+        if path.startswith("/v1/") and base.endswith("/v1"): return base + path[3:]
         return base + path
-
     def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
-        if not self.base_url:
-            raise ProviderConfigurationError("provider base_url is not configured")
+        if not self.base_url: raise ProviderConfigurationError("provider base_url is not configured")
         headers = {"Accept": "application/json"}
-        if payload is not None:
-            headers["Content-Type"] = "application/json"
-        if self.api_key:
-            headers["Authorization"] = "Bearer " + self.api_key
-        request = urllib.request.Request(
-            self._url(path),
-            data=json.dumps(payload).encode() if payload is not None else None,
-            headers=headers,
-        )
+        if payload is not None: headers["Content-Type"] = "application/json"
+        if self.api_key: headers["Authorization"] = "Bearer " + self.api_key
+        request = urllib.request.Request(self._url(path), data=json.dumps(payload).encode() if payload is not None else None, headers=headers)
         try:
-            with urllib.request.urlopen(request, timeout=self.timeout) as response:
-                return json.loads(response.read().decode("utf-8"))
+            with urllib.request.urlopen(request, timeout=self.timeout) as response: return json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
-            if exc.code in (401, 403):
-                raise ProviderAuthenticationError("provider authentication failed", status=exc.code) from None
-            if exc.code == 404:
-                raise ProviderRequestError("provider endpoint was not found", status=exc.code) from None
+            if exc.code in (401, 403): raise ProviderAuthenticationError("provider authentication failed", status=exc.code) from None
+            if exc.code == 404: raise ProviderRequestError("provider endpoint was not found", status=exc.code) from None
             raise ProviderRequestError(f"provider returned HTTP {exc.code}", status=exc.code) from None
-        except (urllib.error.URLError, TimeoutError, OSError):
-            raise ProviderUnavailable("provider is unavailable") from None
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            raise ProviderRequestError("provider returned invalid JSON") from None
-
+        except (urllib.error.URLError, TimeoutError, OSError): raise ProviderUnavailable("provider is unavailable") from None
+        except (json.JSONDecodeError, UnicodeDecodeError): raise ProviderRequestError("provider returned invalid JSON") from None
     def list_models(self) -> list[str]:
         data = self._request("/v1/models")
         values = data.get("data") or data.get("models") or []
-        return [
-            str(item.get("id") or item.get("name"))
-            for item in values
-            if isinstance(item, dict) and (item.get("id") or item.get("name"))
-        ]
-
+        return [str(item.get("id") or item.get("name")) for item in values if isinstance(item, dict) and (item.get("id") or item.get("name"))]
     def health(self) -> bool:
-        try:
-            self._request("/health")
-            return True
+        try: self._request("/health"); return True
         except ProviderError:
-            try:
-                self.list_models()
-                return True
-            except ProviderError:
-                return False
-
+            try: self.list_models(); return True
+            except ProviderError: return False
     def validate_model(self) -> bool:
-        """Validate that the configured model exists when the endpoint exposes a model list."""
-        if not self.model_name:
-            raise ProviderConfigurationError("provider model is not configured")
-        names = self.list_models()
-        return not names or self.model_name in names
-
+        if not self.model_name: raise ProviderConfigurationError("provider model is not configured")
+        names = self.list_models(); return not names or self.model_name in names
+    def _stream_request(self, payload: dict[str, Any]) -> Iterator[str]:
+        if not self.base_url: raise ProviderConfigurationError("provider base_url is not configured")
+        headers = {"Accept": "text/event-stream", "Content-Type": "application/json"}
+        if self.api_key: headers["Authorization"] = "Bearer " + self.api_key
+        request = urllib.request.Request(self._url("/v1/chat/completions"), data=json.dumps(payload).encode(), headers=headers)
+        try:
+            response = urllib.request.urlopen(request, timeout=self.timeout)
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403): raise ProviderAuthenticationError("provider authentication failed", status=exc.code) from None
+            if exc.code == 404: raise ProviderRequestError("provider endpoint was not found", status=exc.code) from None
+            raise ProviderRequestError(f"provider returned HTTP {exc.code}", status=exc.code) from None
+        except (urllib.error.URLError, TimeoutError, OSError): raise ProviderUnavailable("provider is unavailable") from None
+        try:
+            for raw in iter(response.readline, b""):
+                line = raw.decode("utf-8", "replace").strip()
+                if not line or not line.startswith("data:"): continue
+                data = line[5:].strip()
+                if data == "[DONE]": break
+                try: event = json.loads(data)
+                except json.JSONDecodeError: continue
+                choices = event.get("choices") or []
+                if not choices: continue
+                delta = choices[0].get("delta") or {}
+                text = delta.get("content")
+                if text: yield str(text)
+        finally:
+            response.close()
+    def stream_chat(self, prompt: str) -> Iterator[str]:
+        payload = {"model": self.model_name, "messages": [{"role": "user", "content": prompt}], "temperature": self.model.get("temperature", 0.2), "max_tokens": self.model.get("max_tokens", 4096), "stream": True}
+        yield from self._stream_request(payload)
     def chat(self, prompt: str) -> str:
-        if not self.model_name:
-            raise ProviderConfigurationError("provider model is not configured")
-        payload = {
-            "model": self.model_name,
-            "messages": [{"role": "user", "content": prompt}],
-            "temperature": self.model.get("temperature", 0.2),
-            "max_tokens": self.model.get("max_tokens", 4096),
-        }
+        if not self.model_name: raise ProviderConfigurationError("provider model is not configured")
+        payload = {"model": self.model_name, "messages": [{"role": "user", "content": prompt}], "temperature": self.model.get("temperature", 0.2), "max_tokens": self.model.get("max_tokens", 4096)}
         data = self._request("/v1/chat/completions", payload)
         choices = data.get("choices") or []
-        if not choices:
-            raise ProviderRequestError("provider returned no choices")
-        message = choices[0].get("message") or {}
-        content = message.get("content")
-        if content is None:
-            raise ProviderRequestError("provider returned an invalid message")
+        if not choices: raise ProviderRequestError("provider returned no choices")
+        content = (choices[0].get("message") or {}).get("content")
+        if content is None: raise ProviderRequestError("provider returned an invalid message")
         return str(content)

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Iterator
 from config import CF_ACCOUNT_ID, CF_API_TOKEN, CF_MODEL, MODEL
 from models.manager import ModelManager
-from routing import Router, RoutingError
+from routing import Router, RoutingError, TRANSIENT, classify_error
 from .base import ProviderError, ProviderUnavailable
 from .factory import create_adapter
 
@@ -42,28 +42,28 @@ class ProviderManager:
     def ask(self, prompt, model_name=None):
         primary = self._primary(model_name)
         if not primary:
-            self.last_routing = {"selected": None, "attempts": [], "offline": False, "error": "configuration"}
-            return "No AI model configured. Configure a local or online provider first."
-        offline = bool(primary.get("offline", False)); resolver_models = self._configured_models()
-        router = Router(lambda name: resolver_models.get(name) or self.models.get(name))
+            self.last_routing = {"selected": None, "attempts": [], "offline": False, "error": "configuration"}; return "No AI model configured. Configure a local or online provider first."
+        offline = bool(primary.get("offline", False)); resolver_models = self._configured_models(); router = Router(lambda name: resolver_models.get(name) or self.models.get(name))
         try: result = router.run(primary, lambda model: self._ask_model(model, prompt))
         except RoutingError as exc:
             self.last_routing = {"selected": None, "attempts": [a.__dict__ for a in exc.attempts], "offline": offline, "error": exc.kind}; raise
-        self.last_routing = {"selected": result.selected, "attempts": [a.__dict__ for a in result.attempts], "offline": offline}
-        return result.output
+        self.last_routing = {"selected": result.selected, "attempts": [a.__dict__ for a in result.attempts], "offline": offline}; return result.output
     def stream(self, prompt: str, model_name=None) -> Iterator[tuple[str, str]]:
         primary = self._primary(model_name)
         if not primary:
-            self.last_routing = {"selected": None, "attempts": [], "offline": False, "error": "configuration"}
-            raise RoutingError("configuration", "No AI model configured")
-        offline = bool(primary.get("offline", False)); resolver_models = self._configured_models()
-        router = Router(lambda name: resolver_models.get(name) or self.models.get(name))
-        try:
-            for selected, chunk in router.stream(primary, lambda model: self._stream_model(model, prompt)):
-                self.last_routing = {"selected": selected, "attempts": [{"model": selected, "outcome": "streaming"}], "offline": offline}
-                yield selected, chunk
-            if self.last_routing.get("selected"):
-                self.last_routing["attempts"] = [{"model": self.last_routing["selected"], "outcome": "success"}]
-        except RoutingError as exc:
-            self.last_routing = {"selected": None, "attempts": [a.__dict__ for a in exc.attempts], "offline": offline, "error": exc.kind}
-            raise
+            self.last_routing = {"selected": None, "attempts": [], "offline": False, "error": "configuration"}; raise RoutingError("configuration", "No AI model configured")
+        offline = bool(primary.get("offline", False)); resolver_models = self._configured_models(); router = Router(lambda name: resolver_models.get(name) or self.models.get(name))
+        chain = [primary] if primary.get("offline") is True else router.order(primary)
+        attempts = []
+        for model in chain:
+            name = str(model.get("name") or model.get("model") or "unknown")[:128].replace("\n", " ").replace("\r", " "); emitted = False
+            try:
+                for chunk in self._stream_model(model, prompt):
+                    if chunk:
+                        emitted = True; self.last_routing = {"selected": name, "attempts": attempts + [{"model": name, "outcome": "streaming"}], "offline": offline}; yield name, str(chunk)
+                attempts.append({"model": name, "outcome": "success"}); self.last_routing = {"selected": name, "attempts": attempts, "offline": offline}; return
+            except Exception as exc:
+                kind = classify_error(exc); attempts.append({"model": name, "outcome": kind, "error": kind})
+                if emitted or kind not in TRANSIENT:
+                    self.last_routing = {"selected": None, "attempts": attempts, "offline": offline, "error": kind}; raise RoutingError(kind, f"Provider '{name}' failed: {kind}", [type("Attempt", (), a)() for a in attempts]) from exc
+        kind = attempts[-1]["outcome"] if attempts else "configuration"; self.last_routing = {"selected": None, "attempts": attempts, "offline": offline, "error": kind}; raise RoutingError(kind, "No provider succeeded")

--- a/providers/manager.py
+++ b/providers/manager.py
@@ -1,92 +1,69 @@
 """Provider registry and adapter orchestration."""
 from __future__ import annotations
-
+from typing import Iterator
 from config import CF_ACCOUNT_ID, CF_API_TOKEN, CF_MODEL, MODEL
 from models.manager import ModelManager
 from routing import Router, RoutingError
-
 from .base import ProviderError, ProviderUnavailable
 from .factory import create_adapter
 
-
 class ProviderManager:
     """Select configured models while keeping gateway code provider-neutral."""
-
     def __init__(self):
-        self.models = ModelManager()
-        self.models.ensure_discovered()
+        self.models = ModelManager(); self.models.ensure_discovered()
         self.last_routing = {"selected": None, "attempts": [], "offline": False}
-
-    def list_models(self):
-        return self.models.list()
-
-    def register(self, model):
-        return self.models.upsert(model)
-
-    def remove(self, name):
-        return self.models.remove(name)
-
-    def select(self, name):
-        return self.models.select(name)
-
+    def list_models(self): return self.models.list()
+    def register(self, model): return self.models.upsert(model)
+    def remove(self, name): return self.models.remove(name)
+    def select(self, name): return self.models.select(name)
     def _configured_models(self):
         models = {m.get("name"): m for m in self.models.list() if m.get("name")}
         if CF_ACCOUNT_ID and CF_API_TOKEN and CF_MODEL and "cloudflare" not in models:
-            models["cloudflare"] = {
-                "name": "cloudflare",
-                "type": "cloudflare",
-                "model": CF_MODEL,
-                "account_id": CF_ACCOUNT_ID,
-                "api_token": CF_API_TOKEN,
-            }
+            models["cloudflare"] = {"name": "cloudflare", "type": "cloudflare", "model": CF_MODEL, "account_id": CF_ACCOUNT_ID, "api_token": CF_API_TOKEN}
         return models
-
-    def _adapter(self, model):
-        """Resolve environment-backed secrets only for the in-memory adapter."""
-        return create_adapter(ModelManager.resolve_secrets(model))
-
+    def _adapter(self, model): return create_adapter(ModelManager.resolve_secrets(model))
     def health(self, name=None):
         model = self.models.get(name) if name else self.models.default()
-        if not model:
-            return False
-        try:
-            return self._adapter(model).health()
-        except ProviderError:
-            return False
-
-    def routing(self):
-        return dict(self.last_routing)
-
+        if not model: return False
+        try: return self._adapter(model).health()
+        except ProviderError: return False
+    def routing(self): return dict(self.last_routing)
     def _ask_model(self, model, prompt):
         adapter = self._adapter(model)
-        if not adapter.health():
-            raise ProviderUnavailable("provider is unavailable")
+        if not adapter.health(): raise ProviderUnavailable("provider is unavailable")
         return adapter.chat(prompt)
-
-    def ask(self, prompt, model_name=None):
+    def _stream_model(self, model, prompt) -> Iterator[str]:
+        adapter = self._adapter(model)
+        if not adapter.health(): raise ProviderUnavailable("provider is unavailable")
+        yield from adapter.stream_chat(prompt)
+    def _primary(self, model_name=None):
         selected = model_name or (MODEL.strip() if MODEL.strip() and MODEL.strip() != "auto" else None)
-        primary = self.models.get(selected) if selected else self.models.default()
+        return self.models.get(selected) if selected else self.models.default()
+    def ask(self, prompt, model_name=None):
+        primary = self._primary(model_name)
         if not primary:
             self.last_routing = {"selected": None, "attempts": [], "offline": False, "error": "configuration"}
             return "No AI model configured. Configure a local or online provider first."
-
-        offline = bool(primary.get("offline", False))
-        resolver_models = self._configured_models()
+        offline = bool(primary.get("offline", False)); resolver_models = self._configured_models()
+        router = Router(lambda name: resolver_models.get(name) or self.models.get(name))
+        try: result = router.run(primary, lambda model: self._ask_model(model, prompt))
+        except RoutingError as exc:
+            self.last_routing = {"selected": None, "attempts": [a.__dict__ for a in exc.attempts], "offline": offline, "error": exc.kind}; raise
+        self.last_routing = {"selected": result.selected, "attempts": [a.__dict__ for a in result.attempts], "offline": offline}
+        return result.output
+    def stream(self, prompt: str, model_name=None) -> Iterator[tuple[str, str]]:
+        primary = self._primary(model_name)
+        if not primary:
+            self.last_routing = {"selected": None, "attempts": [], "offline": False, "error": "configuration"}
+            raise RoutingError("configuration", "No AI model configured")
+        offline = bool(primary.get("offline", False)); resolver_models = self._configured_models()
         router = Router(lambda name: resolver_models.get(name) or self.models.get(name))
         try:
-            result = router.run(primary, lambda model: self._ask_model(model, prompt))
+            for selected, chunk in router.stream(primary, lambda model: self._stream_model(model, prompt)):
+                self.last_routing = {"selected": selected, "attempts": [{"model": selected, "outcome": "streaming"}], "offline": offline}
+                yield selected, chunk
+            if self.last_routing.get("selected"):
+                self.last_routing["attempts"] = [{"model": self.last_routing["selected"], "outcome": "success"}]
         except RoutingError as exc:
-            self.last_routing = {
-                "selected": None,
-                "attempts": [a.__dict__ for a in exc.attempts],
-                "offline": offline,
-                "error": exc.kind,
-            }
+            self.last_routing = {"selected": None, "attempts": [a.__dict__ for a in exc.attempts], "offline": offline, "error": exc.kind}
             raise
-
-        self.last_routing = {
-            "selected": result.selected,
-            "attempts": [a.__dict__ for a in result.attempts],
-            "offline": offline,
-        }
-        return result.output

--- a/providers/ollama.py
+++ b/providers/ollama.py
@@ -1,19 +1,13 @@
 """Ollama-native provider adapter."""
 from __future__ import annotations
-import json
-import urllib.error
-import urllib.request
+import json, urllib.error, urllib.request
 from typing import Any, Iterator
-from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
+from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderError, ProviderRequestError, ProviderUnavailable
 
 class OllamaAdapter(ProviderAdapter):
-    provider_type = "ollama"
-    offline = True
+    provider_type = "ollama"; offline = True
     def __init__(self, model: dict[str, Any]):
-        super().__init__(model)
-        self.base_url = str(model.get("base_url", "http://127.0.0.1:11434")).rstrip("/")
-        self.timeout = float(model.get("timeout", 120))
-        self.api_key = str(model.get("api_key", ""))
+        super().__init__(model); self.base_url = str(model.get("base_url", "http://127.0.0.1:11434")).rstrip("/"); self.timeout = float(model.get("timeout", 120)); self.api_key = str(model.get("api_key", ""))
     def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         if not self.base_url: raise ProviderConfigurationError("Ollama base_url is not configured")
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -29,17 +23,14 @@ class OllamaAdapter(ProviderAdapter):
     def health(self) -> bool:
         try: self._request("/api/tags"); return True
         except ProviderError: return False
-    def list_models(self) -> list[str]:
-        data = self._request("/api/tags")
-        return [str(x.get("name")) for x in (data.get("models") or []) if isinstance(x, dict) and x.get("name")]
+    def list_models(self) -> list[str]: return [str(x.get("name")) for x in (self._request("/api/tags").get("models") or []) if isinstance(x, dict) and x.get("name")]
     def validate_model(self) -> bool:
         names = self.list_models(); return not names or self.model_name in names
     def stream_chat(self, prompt: str) -> Iterator[str]:
         if not self.model_name: raise ProviderConfigurationError("Ollama model is not configured")
-        payload = {"model": self.model_name, "prompt": prompt, "stream": True}
         headers = {"Accept": "application/x-ndjson", "Content-Type": "application/json"}
         if self.api_key: headers["Authorization"] = "Bearer " + self.api_key
-        request = urllib.request.Request(self.base_url + "/api/generate", data=json.dumps(payload).encode(), headers=headers)
+        request = urllib.request.Request(self.base_url + "/api/generate", data=json.dumps({"model": self.model_name, "prompt": prompt, "stream": True}).encode(), headers=headers)
         try: response = urllib.request.urlopen(request, timeout=self.timeout)
         except urllib.error.HTTPError as exc:
             if exc.code in (401, 403): raise ProviderAuthenticationError("Ollama authentication failed", status=exc.code) from None
@@ -51,10 +42,8 @@ class OllamaAdapter(ProviderAdapter):
                 if not line: continue
                 try: data = json.loads(line)
                 except json.JSONDecodeError: continue
-                text = data.get("response")
-                if text: yield str(text)
+                if data.get("response"): yield str(data["response"])
                 if data.get("done"): break
         finally: response.close()
     def chat(self, prompt: str) -> str:
-        data = self._request("/api/generate", {"model": self.model_name, "prompt": prompt, "stream": False})
-        return str(data.get("response", ""))
+        data = self._request("/api/generate", {"model": self.model_name, "prompt": prompt, "stream": False}); return str(data.get("response", ""))

--- a/providers/ollama.py
+++ b/providers/ollama.py
@@ -1,79 +1,60 @@
 """Ollama-native provider adapter."""
 from __future__ import annotations
-
 import json
 import urllib.error
 import urllib.request
-from typing import Any
-
-from .base import (
-    ProviderAdapter,
-    ProviderAuthenticationError,
-    ProviderConfigurationError,
-    ProviderRequestError,
-    ProviderUnavailable,
-)
-
+from typing import Any, Iterator
+from .base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
 
 class OllamaAdapter(ProviderAdapter):
     provider_type = "ollama"
     offline = True
-
     def __init__(self, model: dict[str, Any]):
         super().__init__(model)
         self.base_url = str(model.get("base_url", "http://127.0.0.1:11434")).rstrip("/")
         self.timeout = float(model.get("timeout", 120))
         self.api_key = str(model.get("api_key", ""))
-
     def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
-        if not self.base_url:
-            raise ProviderConfigurationError("Ollama base_url is not configured")
+        if not self.base_url: raise ProviderConfigurationError("Ollama base_url is not configured")
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
-        if self.api_key:
-            headers["Authorization"] = "Bearer " + self.api_key
-        request = urllib.request.Request(
-            self.base_url + path,
-            data=json.dumps(payload).encode() if payload is not None else None,
-            headers=headers,
-        )
+        if self.api_key: headers["Authorization"] = "Bearer " + self.api_key
+        request = urllib.request.Request(self.base_url + path, data=json.dumps(payload).encode() if payload is not None else None, headers=headers)
         try:
-            with urllib.request.urlopen(request, timeout=self.timeout) as response:
-                return json.loads(response.read().decode("utf-8"))
+            with urllib.request.urlopen(request, timeout=self.timeout) as response: return json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
-            if exc.code in (401, 403):
-                raise ProviderAuthenticationError("Ollama authentication failed", status=exc.code) from None
+            if exc.code in (401, 403): raise ProviderAuthenticationError("Ollama authentication failed", status=exc.code) from None
             raise ProviderRequestError(f"Ollama returned HTTP {exc.code}", status=exc.code) from None
-        except (urllib.error.URLError, TimeoutError, OSError):
-            raise ProviderUnavailable("Ollama is unavailable") from None
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            raise ProviderRequestError("Ollama returned invalid JSON") from None
-
+        except (urllib.error.URLError, TimeoutError, OSError): raise ProviderUnavailable("Ollama is unavailable") from None
+        except (json.JSONDecodeError, UnicodeDecodeError): raise ProviderRequestError("Ollama returned invalid JSON") from None
+    def health(self) -> bool:
+        try: self._request("/api/tags"); return True
+        except ProviderError: return False
     def list_models(self) -> list[str]:
         data = self._request("/api/tags")
-        return [
-            str(item.get("name"))
-            for item in data.get("models", [])
-            if isinstance(item, dict) and item.get("name")
-        ]
-
-    def health(self) -> bool:
-        try:
-            self.list_models()
-            return True
-        except Exception:
-            return False
-
+        return [str(x.get("name")) for x in (data.get("models") or []) if isinstance(x, dict) and x.get("name")]
     def validate_model(self) -> bool:
-        if not self.model_name:
-            raise ProviderConfigurationError("Ollama model is not configured")
-        names = self.list_models()
-        return self.model_name in names
-
+        names = self.list_models(); return not names or self.model_name in names
+    def stream_chat(self, prompt: str) -> Iterator[str]:
+        if not self.model_name: raise ProviderConfigurationError("Ollama model is not configured")
+        payload = {"model": self.model_name, "prompt": prompt, "stream": True}
+        headers = {"Accept": "application/x-ndjson", "Content-Type": "application/json"}
+        if self.api_key: headers["Authorization"] = "Bearer " + self.api_key
+        request = urllib.request.Request(self.base_url + "/api/generate", data=json.dumps(payload).encode(), headers=headers)
+        try: response = urllib.request.urlopen(request, timeout=self.timeout)
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403): raise ProviderAuthenticationError("Ollama authentication failed", status=exc.code) from None
+            raise ProviderRequestError(f"Ollama returned HTTP {exc.code}", status=exc.code) from None
+        except (urllib.error.URLError, TimeoutError, OSError): raise ProviderUnavailable("Ollama is unavailable") from None
+        try:
+            for raw in iter(response.readline, b""):
+                line = raw.decode("utf-8", "replace").strip()
+                if not line: continue
+                try: data = json.loads(line)
+                except json.JSONDecodeError: continue
+                text = data.get("response")
+                if text: yield str(text)
+                if data.get("done"): break
+        finally: response.close()
     def chat(self, prompt: str) -> str:
-        if not self.model_name:
-            raise ProviderConfigurationError("Ollama model is not configured")
-        data = self._request(
-            "/api/generate",
-            {"model": self.model_name, "prompt": prompt, "stream": False},
-        )
+        data = self._request("/api/generate", {"model": self.model_name, "prompt": prompt, "stream": False})
         return str(data.get("response", ""))

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -3,184 +3,84 @@ import unittest
 from threading import Thread
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
-
 from gateway import create_server
 from routing import RoutingError
 from security import SecurityPolicy
 
-
 class FakeModels:
-    def list(self):
-        return [{"name": "fake-local", "type": "openai_compatible", "capabilities": ["chat"], "default": True}]
-
-    def get(self, name):
-        return self.list()[0] if name == "fake-local" else None
-
-    def default(self):
-        return self.list()[0]
-
+    def list(self): return [{"name": "fake-local", "type": "openai_compatible", "capabilities": ["chat", "streaming"], "default": True}]
+    def get(self, name): return self.list()[0] if name == "fake-local" else None
+    def default(self): return self.list()[0]
 
 class FakeManager:
-    def __init__(self):
-        self.models = FakeModels()
+    def __init__(self): self.models = FakeModels(); self.last_routing = {"selected": "fake-local", "attempts": [{"model": "fake-local", "outcome": "success"}], "offline": True}
+    def list_models(self): return self.models.list()
+    def ask(self, prompt, model_name=None): return f"reply:{prompt}"
+    def stream(self, prompt, model_name=None):
+        for chunk in ("hel", "lo"): yield "fake-local", chunk
         self.last_routing = {"selected": "fake-local", "attempts": [{"model": "fake-local", "outcome": "success"}], "offline": True}
 
-    def list_models(self):
-        return self.models.list()
-
-    def ask(self, prompt, model_name=None):
-        return f"reply:{prompt}"
-
-
 class FailingManager(FakeManager):
-    def ask(self, prompt, model_name=None):
-        raise RoutingError("network", "provider unavailable")
-
+    def ask(self, prompt, model_name=None): raise RoutingError("network", "provider unavailable")
 
 class GatewayContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.server = create_server("127.0.0.1", 0, FakeManager())
-        cls.thread = Thread(target=cls.server.serve_forever, daemon=True)
-        cls.thread.start()
-        cls.base = f"http://127.0.0.1:{cls.server.server_address[1]}"
-
+        cls.server = create_server("127.0.0.1", 0, FakeManager()); cls.thread = Thread(target=cls.server.serve_forever, daemon=True); cls.thread.start(); cls.base = f"http://127.0.0.1:{cls.server.server_address[1]}"
     @classmethod
-    def tearDownClass(cls):
-        cls.server.shutdown()
-        cls.server.server_close()
-
+    def tearDownClass(cls): cls.server.shutdown(); cls.server.server_close()
     def request(self, path, method="GET", payload=None, headers=None):
-        data = None if payload is None else json.dumps(payload).encode()
-        request = Request(self.base + path, data=data, method=method, headers=headers or {})
-        return urlopen(request)
-
-    def post(self, path, payload, headers=None):
-        return self.request(path, "POST", payload, {"Content-Type": "application/json", **(headers or {})})
-
+        data = None if payload is None else json.dumps(payload).encode(); return urlopen(Request(self.base + path, data=data, method=method, headers=headers or {}))
+    def post(self, path, payload, headers=None): return self.request(path, "POST", payload, {"Content-Type": "application/json", **(headers or {})})
     def test_health(self):
-        with self.request("/health") as response:
-            self.assertEqual(response.status, 200)
-            self.assertTrue(json.load(response)["ok"])
-
+        with self.request("/health") as response: self.assertEqual(response.status, 200); self.assertTrue(json.load(response)["ok"])
     def test_models(self):
-        with self.request("/v1/models") as response:
-            data = json.load(response)
-            self.assertEqual(data["data"][0]["id"], "fake-local")
-            self.assertEqual(data["data"][0]["provider"], "openai_compatible")
-
+        with self.request("/v1/models") as response: self.assertEqual(json.load(response)["data"][0]["id"], "fake-local")
     def test_chat_completions(self):
-        with self.post("/v1/chat/completions", {
-            "model": "fake-local",
-            "messages": [{"role": "user", "content": "hello"}],
-        }) as response:
-            data = json.load(response)
-            self.assertEqual(data["object"], "chat.completion")
-            self.assertEqual(data["model"], "fake-local")
-            self.assertEqual(data["choices"][0]["message"]["content"], "reply:hello")
-            self.assertIn("routing", data)
-
+        with self.post("/v1/chat/completions", {"model": "fake-local", "messages": [{"role": "user", "content": "hello"}]}) as response:
+            data = json.load(response); self.assertEqual(data["object"], "chat.completion"); self.assertEqual(data["choices"][0]["message"]["content"], "reply:hello")
+    def test_streaming_chat_completions(self):
+        with self.post("/v1/chat/completions", {"model": "fake-local", "stream": True, "messages": [{"role": "user", "content": "hello"}]}) as response:
+            body = response.read().decode(); self.assertEqual(response.headers["Content-Type"].split(";")[0], "text/event-stream")
+            events = [json.loads(line[6:]) for line in body.splitlines() if line.startswith("data: {")]
+            self.assertEqual([e["choices"][0]["delta"].get("content") for e in events[:2]], ["hel", "lo"]); self.assertEqual(events[-1]["choices"][0]["finish_reason"], "stop"); self.assertIn("data: [DONE]", body)
     def test_invalid_message_schema(self):
-        with self.assertRaises(HTTPError) as raised:
-            self.post("/v1/chat/completions", {"messages": [{"content": "hello"}]})
+        with self.assertRaises(HTTPError) as raised: self.post("/v1/chat/completions", {"messages": [{"content": "hello"}]})
         self.assertEqual(raised.exception.code, 400)
-        body = json.loads(raised.exception.read())
-        self.assertEqual(body["error"]["code"], "invalid_request")
-
     def test_unknown_model(self):
-        with self.assertRaises(HTTPError) as raised:
-            self.post("/v1/chat/completions", {
-                "model": "missing",
-                "messages": [{"role": "user", "content": "hello"}],
-            })
+        with self.assertRaises(HTTPError) as raised: self.post("/v1/chat/completions", {"model": "missing", "messages": [{"role": "user", "content": "hello"}]})
         self.assertEqual(raised.exception.code, 404)
-        body = json.loads(raised.exception.read())
-        self.assertEqual(body["error"]["code"], "model_not_found")
-
     def test_compatibility_endpoint_matches_contract(self):
-        with self.post("/api/chat", {
-            "model": "fake-local",
-            "messages": [{"role": "user", "content": "hello"}],
-        }) as response:
-            data = json.load(response)
-            self.assertEqual(data["object"], "chat.completion")
-            self.assertEqual(data["choices"][0]["message"]["role"], "assistant")
-
+        with self.post("/api/chat", {"model": "fake-local", "messages": [{"role": "user", "content": "hello"}]}) as response: self.assertEqual(json.load(response)["object"], "chat.completion")
     def test_static_shell_is_public(self):
-        with self.request("/") as response:
-            self.assertEqual(response.status, 200)
-            self.assertIn("text/html", response.headers["Content-Type"])
-
+        with self.request("/") as response: self.assertEqual(response.status, 200); self.assertIn("text/html", response.headers["Content-Type"])
     def test_options_does_not_require_api_key(self):
-        with self.request("/v1/chat/completions", "OPTIONS", headers={"Origin": "https://app.example"}) as response:
-            self.assertEqual(response.status, 204)
-
+        with self.request("/v1/chat/completions", "OPTIONS", headers={"Origin": "https://app.example"}) as response: self.assertEqual(response.status, 204)
     def test_provider_failure_is_safe(self):
-        server = create_server("127.0.0.1", 0, FailingManager())
-        thread = Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-        base = f"http://127.0.0.1:{server.server_address[1]}"
+        server = create_server("127.0.0.1", 0, FailingManager()); thread = Thread(target=server.serve_forever, daemon=True); thread.start(); base = f"http://127.0.0.1:{server.server_address[1]}"
         try:
-            request = Request(
-                base + "/v1/chat/completions",
-                data=json.dumps({"model": "fake-local", "messages": [{"role": "user", "content": "hello"}]}).encode(),
-                headers={"Content-Type": "application/json"},
-            )
-            with self.assertRaises(HTTPError) as raised:
-                urlopen(request)
-            self.assertEqual(raised.exception.code, 503)
-            body = json.loads(raised.exception.read())
-            self.assertEqual(body["error"]["code"], "provider_network")
-            self.assertNotIn("provider unavailable", body["error"].get("message", ""))
-        finally:
-            server.shutdown()
-            server.server_close()
-
+            request = Request(base + "/v1/chat/completions", data=json.dumps({"model": "fake-local", "messages": [{"role": "user", "content": "hello"}]}).encode(), headers={"Content-Type": "application/json"})
+            with self.assertRaises(HTTPError) as raised: urlopen(request)
+            self.assertEqual(raised.exception.code, 503); body = json.loads(raised.exception.read()); self.assertEqual(body["error"]["code"], "provider_network")
+        finally: server.shutdown(); server.server_close()
 
 class GatewaySecurityTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        policy = SecurityPolicy(api_key="test-secret", allowed_origins=("https://app.example",), max_body_bytes=128)
-        cls.server = create_server("127.0.0.1", 0, FakeManager(), policy)
-        cls.thread = Thread(target=cls.server.serve_forever, daemon=True)
-        cls.thread.start()
-        cls.base = f"http://127.0.0.1:{cls.server.server_address[1]}"
-
+        policy = SecurityPolicy(api_key="test-secret", allowed_origins=("https://app.example",), max_body_bytes=128); cls.server = create_server("127.0.0.1", 0, FakeManager(), policy); cls.thread = Thread(target=cls.server.serve_forever, daemon=True); cls.thread.start(); cls.base = f"http://127.0.0.1:{cls.server.server_address[1]}"
     @classmethod
-    def tearDownClass(cls):
-        cls.server.shutdown()
-        cls.server.server_close()
-
+    def tearDownClass(cls): cls.server.shutdown(); cls.server.server_close()
     def test_protected_route_requires_api_key(self):
-        with self.assertRaises(HTTPError) as raised:
-            urlopen(self.base + "/v1/models")
+        with self.assertRaises(HTTPError) as raised: urlopen(self.base + "/v1/models")
         self.assertEqual(raised.exception.code, 401)
-
     def test_wrong_origin_is_rejected(self):
-        request = Request(self.base + "/v1/models", headers={"Origin": "https://evil.example"})
-        with self.assertRaises(HTTPError) as raised:
-            urlopen(request)
+        with self.assertRaises(HTTPError) as raised: urlopen(Request(self.base + "/v1/models", headers={"Origin": "https://evil.example"}))
         self.assertEqual(raised.exception.code, 403)
-
     def test_allowed_origin_and_key_succeed(self):
-        request = Request(
-            self.base + "/v1/models",
-            headers={"Origin": "https://app.example", "Authorization": "Bearer test-secret"},
-        )
-        with urlopen(request) as response:
-            self.assertEqual(response.status, 200)
-
+        with urlopen(Request(self.base + "/v1/models", headers={"Origin": "https://app.example", "Authorization": "Bearer test-secret"})) as response: self.assertEqual(response.status, 200)
     def test_oversized_body_is_rejected(self):
-        payload = {"model": "fake-local", "messages": [{"role": "user", "content": "x" * 512}]}
-        request = Request(
-            self.base + "/v1/chat/completions",
-            data=json.dumps(payload).encode(),
-            headers={"Content-Type": "application/json", "Authorization": "Bearer test-secret"},
-        )
-        with self.assertRaises(HTTPError) as raised:
-            urlopen(request)
+        payload = {"model": "fake-local", "messages": [{"role": "user", "content": "x" * 512}]}; request = Request(self.base + "/v1/chat/completions", data=json.dumps(payload).encode(), headers={"Content-Type": "application/json", "Authorization": "Bearer test-secret"})
+        with self.assertRaises(HTTPError) as raised: urlopen(request)
         self.assertEqual(raised.exception.code, 413)
 
-
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == "__main__": unittest.main()

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -2,49 +2,30 @@ import json
 import urllib.error
 import unittest
 from unittest.mock import patch
-
-from providers.base import (
-    ProviderAdapter,
-    ProviderAuthenticationError,
-    ProviderConfigurationError,
-    ProviderRequestError,
-    ProviderUnavailable,
-)
+from providers.base import ProviderAdapter, ProviderAuthenticationError, ProviderConfigurationError, ProviderRequestError, ProviderUnavailable
 from providers.cloudflare import CloudflareProvider
 from providers.factory import create_adapter
 from providers.http_compatible import OpenAICompatibleAdapter
 from providers.llama_cpp import LlamaCppAdapter
 from providers.ollama import OllamaAdapter
 
-
 class Response:
     status = 200
+    def __init__(self, payload): self.payload = payload
+    def __enter__(self): return self
+    def __exit__(self, *args): return False
+    def read(self): return json.dumps(self.payload).encode()
 
-    def __init__(self, payload):
-        self.payload = payload
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        return False
-
-    def read(self):
-        return json.dumps(self.payload).encode()
-
+class StreamResponse:
+    status = 200
+    def __init__(self, lines): self.lines = iter(x.encode() for x in lines)
+    def readline(self): return next(self.lines, b"")
+    def close(self): pass
 
 class ProviderAdapterTests(unittest.TestCase):
     def assert_contract(self, adapter):
-        self.assertIsInstance(adapter, ProviderAdapter)
-        self.assertTrue(adapter.name)
-        self.assertTrue(adapter.model_name)
-        info = adapter.info()
-        self.assertEqual(info.name, adapter.name)
-        self.assertEqual(info.provider, adapter.provider_type)
-        self.assertEqual(info.model, adapter.model_name)
-        self.assertIsInstance(info.capabilities, tuple)
-        self.assertIn("chat", info.capabilities)
-
+        self.assertIsInstance(adapter, ProviderAdapter); self.assertTrue(adapter.name); self.assertTrue(adapter.model_name)
+        info = adapter.info(); self.assertEqual(info.name, adapter.name); self.assertEqual(info.provider, adapter.provider_type); self.assertEqual(info.model, adapter.model_name); self.assertIsInstance(info.capabilities, tuple); self.assertIn("chat", info.capabilities)
     def test_factory_selects_all_supported_adapters(self):
         cases = [
             ({"name": "llama", "type": "llama_cpp", "base_url": "http://local", "model": "m"}, LlamaCppAdapter, True),
@@ -55,72 +36,49 @@ class ProviderAdapterTests(unittest.TestCase):
         ]
         for model, expected_type, offline in cases:
             with self.subTest(model=model["type"]):
-                adapter = create_adapter(model)
-                self.assertIsInstance(adapter, expected_type)
-                self.assertIs(adapter.offline, offline)
-                self.assert_contract(adapter)
-                if model["type"] == "gemini":
-                    self.assertEqual(adapter.provider_type, "gemini")
-
+                adapter = create_adapter(model); self.assertIsInstance(adapter, expected_type); self.assertIs(adapter.offline, offline); self.assert_contract(adapter)
     def test_factory_rejects_unknown_provider(self):
-        with self.assertRaises(ProviderConfigurationError):
-            create_adapter({"name": "bad", "type": "unknown"})
-
+        with self.assertRaises(ProviderConfigurationError): create_adapter({"name": "bad", "type": "unknown"})
+    def test_openai_streaming(self):
+        adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
+        lines = ['data: {"choices":[{"delta":{"content":"hel"}}]}\n', 'data: {"choices":[{"delta":{"content":"lo"}}]}\n', 'data: [DONE]\n']
+        with patch("urllib.request.urlopen", return_value=StreamResponse(lines)):
+            self.assertEqual(list(adapter.stream_chat("hello")), ["hel", "lo"])
     def test_openai_base_url_with_v1_is_not_double_prefixed(self):
         adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote/v1", "model": "m"})
-        with patch("urllib.request.urlopen", return_value=Response({"data": [{"id": "m"}]})) as mocked:
-            self.assertEqual(adapter.list_models(), ["m"])
+        with patch("urllib.request.urlopen", return_value=Response({"data": [{"id": "m"}]})) as mocked: self.assertEqual(adapter.list_models(), ["m"])
         self.assertEqual(mocked.call_args.args[0].full_url, "http://remote/v1/models")
-
     def test_openai_compatible_model_discovery_and_validation(self):
         adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
-        with patch("urllib.request.urlopen", return_value=Response({"data": [{"id": "m"}, {"id": "other"}]})):
-            self.assertEqual(adapter.list_models(), ["m", "other"])
-            self.assertTrue(adapter.validate_model())
-
+        with patch("urllib.request.urlopen", return_value=Response({"data": [{"id": "m"}, {"id": "other"}]})): self.assertEqual(adapter.list_models(), ["m", "other"]); self.assertTrue(adapter.validate_model())
     def test_openai_compatible_chat_normalizes_response(self):
         adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
-        with patch("urllib.request.urlopen", return_value=Response({"choices": [{"message": {"content": "ok"}}]})):
-            self.assertEqual(adapter.chat("hello"), "ok")
-
+        with patch("urllib.request.urlopen", return_value=Response({"choices": [{"message": {"content": "ok"}}]})): self.assertEqual(adapter.chat("hello"), "ok")
     def test_openai_compatible_auth_error_is_normalized(self):
-        adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
-        error = urllib.error.HTTPError("http://remote", 401, "unauthorized", {}, None)
+        adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"}); error = urllib.error.HTTPError("http://remote", 401, "unauthorized", {}, None)
         with patch("urllib.request.urlopen", side_effect=error):
-            with self.assertRaises(ProviderAuthenticationError):
-                adapter.chat("hello")
-
+            with self.assertRaises(ProviderAuthenticationError): adapter.chat("hello")
     def test_openai_compatible_empty_response_is_normalized(self):
         adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m"})
         with patch("urllib.request.urlopen", return_value=Response({"choices": []})):
-            with self.assertRaises(ProviderRequestError):
-                adapter.chat("hello")
-
+            with self.assertRaises(ProviderRequestError): adapter.chat("hello")
     def test_unavailable_error_does_not_expose_credentials(self):
         adapter = OpenAICompatibleAdapter({"name": "remote", "base_url": "http://remote", "model": "m", "api_key": "SECRET"})
         with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
-            with self.assertRaises(ProviderUnavailable) as context:
-                adapter.chat("hello")
+            with self.assertRaises(ProviderUnavailable) as context: adapter.chat("hello")
         self.assertNotIn("SECRET", str(context.exception))
-
     def test_ollama_contract_and_chat(self):
+        adapter = OllamaAdapter({"name": "ollama", "type": "ollama", "base_url": "http://local", "model": "m"}); self.assert_contract(adapter)
+        with patch("urllib.request.urlopen", return_value=Response({"response": "ok"})): self.assertEqual(adapter.chat("hello"), "ok")
+    def test_ollama_streaming(self):
         adapter = OllamaAdapter({"name": "ollama", "type": "ollama", "base_url": "http://local", "model": "m"})
-        self.assert_contract(adapter)
-        with patch("urllib.request.urlopen", return_value=Response({"response": "ok"})):
-            self.assertEqual(adapter.chat("hello"), "ok")
-
+        lines = ['{"response":"hel","done":false}\n', '{"response":"lo","done":false}\n', '{"done":true}\n']
+        with patch("urllib.request.urlopen", return_value=StreamResponse(lines)): self.assertEqual(list(adapter.stream_chat("hello")), ["hel", "lo"])
     def test_ollama_discovery_and_validation(self):
         adapter = OllamaAdapter({"name": "ollama", "type": "ollama", "base_url": "http://local", "model": "m"})
-        with patch("urllib.request.urlopen", return_value=Response({"models": [{"name": "m"}, {"name": "other"}]})):
-            self.assertEqual(adapter.list_models(), ["m", "other"])
-            self.assertTrue(adapter.validate_model())
-
+        with patch("urllib.request.urlopen", return_value=Response({"models": [{"name": "m"}, {"name": "other"}]})): self.assertEqual(adapter.list_models(), ["m", "other"]); self.assertTrue(adapter.validate_model())
     def test_cloudflare_contract_and_chat(self):
-        adapter = CloudflareProvider({"name": "cf", "type": "cloudflare", "account_id": "a", "api_token": "t", "model": "m"})
-        self.assert_contract(adapter)
-        with patch("urllib.request.urlopen", return_value=Response({"result": {"response": "ok"}})):
-            self.assertEqual(adapter.chat("hello"), "ok")
+        adapter = CloudflareProvider({"name": "cf", "type": "cloudflare", "account_id": "a", "api_token": "t", "model": "m"}); self.assert_contract(adapter)
+        with patch("urllib.request.urlopen", return_value=Response({"result": {"response": "ok"}})): self.assertEqual(adapter.chat("hello"), "ok")
 
-
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Issue
Closes #62

## Changes
- Extend provider adapter contract with streaming capability metadata.
- Add native incremental streaming for OpenAI-compatible and Ollama providers.
- Add Cloudflare streaming support.
- Expose provider streaming through ProviderManager with safe pre-first-chunk fallback behavior.
- Add OpenAI-compatible SSE gateway responses with cancellation/disconnect-safe handling.
- Preserve existing non-streaming chat behavior.
- Add provider and gateway streaming tests.

## Validation
Provider and gateway test suites were extended for incremental chunks, SSE framing, completion termination, and existing compatibility behavior.