### PR TITLE
feat: implement documentation generator and project reports (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,34 @@ Copy `.env.example` as a reference and keep secrets/runtime state outside Git.
 - Generic local AI adapter
 - Cloudflare gateway
 - Modular architecture
+- Deterministic source documentation and project reports
 
 ## Local model portability
 
 For llama.cpp, point `YASIN_LOCAL_BASE_URL` at its OpenAI-compatible `/v1` API and set `YASIN_LOCAL_MODEL` to the alias exposed by that server. The model file itself remains outside the repository and can be any compatible model selected by the user.
 
 For Ollama, set `YASIN_LOCAL_RUNTIME=ollama`, point `YASIN_LOCAL_BASE_URL` at the Ollama server, and set `YASIN_LOCAL_MODEL` to the installed model name.
+
+## Documentation and project reports
+
+The `docs` command analyzes Python source with the standard-library AST parser and never imports application code. Runtime directories, environment files, model registries and build artifacts are excluded.
+
+```bash
+python main.py docs api
+python main.py docs architecture
+python main.py docs report
+python main.py docs changes --base HEAD^
+python main.py docs all
+```
+
+`docs all` writes only generator-owned files under `docs/generated/`:
+
+- `api.md` — source-derived API inventory
+- `architecture.md` — deterministic module/import map
+- `report.json` — project metrics and changed-file summary
+- `changes.json` — bounded git change summary
+
+A single report can be written elsewhere with `--output FILE`. Hand-written documentation outside `docs/generated/` is never overwritten.
 
 ## Tests
 

--- a/commands/docs.py
+++ b/commands/docs.py
@@ -1,0 +1,18 @@
+from core.documentation import render, write_generated
+
+
+class DocsCommand:
+    """Generate deterministic source documentation and project reports."""
+
+    def run(self, action="all", *, base_ref="HEAD^", output=None):
+        if action == "all":
+            paths = write_generated(".", base_ref)
+            return "\n".join(f"generated: {p}" for p in paths)
+        if action not in {"api", "architecture", "report", "changes"}:
+            raise ValueError("Usage: docs [all|api|architecture|report|changes] [--base REF] [--output FILE]")
+        content = render(action, ".", base_ref)
+        if output:
+            with open(output, "w", encoding="utf-8") as handle:
+                handle.write(content)
+            return f"generated: {output}"
+        return content.rstrip()

--- a/core/documentation.py
+++ b/core/documentation.py
@@ -11,7 +11,6 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Iterable
 
 GENERATED_DIR = Path("docs/generated")
 SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", "build", "dist", ".pytest_cache", ".mypy_cache"}
@@ -151,9 +150,9 @@ def _redact(text: str) -> str:
 def render(kind: str, root: str = ".", base_ref: str = "HEAD^") -> str:
     records = analyze(root)
     if kind == "api":
-        return api_markdown(records)
+        return _redact(api_markdown(records))
     if kind == "architecture":
-        return architecture_markdown(records)
+        return _redact(architecture_markdown(records))
     if kind == "changes":
         return _redact(json.dumps(changed_files(root, base_ref), indent=2, sort_keys=True) + "\n")
     if kind == "report":
@@ -174,7 +173,6 @@ def write_generated(root: str = ".", base_ref: str = "HEAD^") -> list[Path]:
     written = []
     for kind, filename in outputs.items():
         path = out / filename
-        # Only files owned by this generator may be replaced.
         content = render(kind, str(base), base_ref)
         path.write_text(content, encoding="utf-8")
         written.append(path)

--- a/core/documentation.py
+++ b/core/documentation.py
@@ -1,0 +1,181 @@
+"""Deterministic, source-only documentation and project reporting.
+
+The generator intentionally avoids importing application modules or reading runtime
+state. Only source files and selected git metadata are inspected.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+GENERATED_DIR = Path("docs/generated")
+SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", "build", "dist", ".pytest_cache", ".mypy_cache"}
+SKIP_FILES = {".env", ".env.local", ".env.production", "models.json", "index.json"}
+SECRET_RE = re.compile(r"(?i)(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*[^\s,}]+")
+
+
+def _safe_path(path: Path) -> bool:
+    return not any(part in SKIP_DIRS for part in path.parts) and path.name not in SKIP_FILES
+
+
+def source_files(root: str | os.PathLike[str] = ".") -> list[Path]:
+    base = Path(root).resolve()
+    files = [p for p in base.rglob("*.py") if _safe_path(p.relative_to(base))]
+    return sorted(files, key=lambda p: p.relative_to(base).as_posix())
+
+
+def _parse(path: Path) -> ast.Module | None:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, UnicodeDecodeError, SyntaxError):
+        return None
+
+
+def _doc(node: ast.AST) -> str:
+    text = ast.get_docstring(node) or ""
+    return " ".join(text.split())
+
+
+def analyze(root: str | os.PathLike[str] = ".") -> list[dict]:
+    base = Path(root).resolve()
+    records: list[dict] = []
+    for path in source_files(base):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        rel = path.relative_to(base).as_posix()
+        classes = []
+        functions = []
+        imports = []
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                classes.append({"name": node.name, "doc": _doc(node)})
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                functions.append({"name": node.name, "async": isinstance(node, ast.AsyncFunctionDef), "doc": _doc(node)})
+            elif isinstance(node, ast.Import):
+                imports.extend(sorted(alias.name for alias in node.names))
+            elif isinstance(node, ast.ImportFrom):
+                imports.append(node.module or ".")
+        records.append({
+            "path": rel,
+            "lines": len(path.read_text(encoding="utf-8").splitlines()),
+            "classes": classes,
+            "functions": functions,
+            "imports": sorted(set(imports)),
+            "module_doc": _doc(tree),
+        })
+    return records
+
+
+def api_markdown(records: list[dict]) -> str:
+    lines = ["# API Reference", "", "Generated deterministically from Python source. No application modules are imported.", ""]
+    for item in records:
+        lines += [f"## `{item['path']}`", ""]
+        if item["module_doc"]:
+            lines += [item["module_doc"], ""]
+        if item["classes"]:
+            lines += ["### Classes", ""]
+            for cls in item["classes"]:
+                suffix = f" — {cls['doc']}" if cls["doc"] else ""
+                lines.append(f"- `{cls['name']}`{suffix}")
+            lines.append("")
+        if item["functions"]:
+            lines += ["### Functions", ""]
+            for fn in item["functions"]:
+                prefix = "async " if fn["async"] else ""
+                suffix = f" — {fn['doc']}" if fn["doc"] else ""
+                lines.append(f"- `{prefix}{fn['name']}`{suffix}")
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def architecture_markdown(records: list[dict]) -> str:
+    lines = ["# Architecture", "", "Source-derived module map. Imports are reported as declared, without executing code.", "", "```mermaid", "flowchart TD"]
+    nodes: list[str] = []
+    edges: list[str] = []
+    for i, item in enumerate(records):
+        node = f"N{i}"
+        label = item["path"].replace('"', "'")
+        nodes.append(f'    {node}["{label}"]')
+        for imported in item["imports"]:
+            target = next((j for j, r in enumerate(records) if r["path"] == imported or r["path"].startswith(imported.replace('.', '/') + "/")), None)
+            if target is not None and target != i:
+                edges.append(f"    N{i} --> N{target}")
+    lines += nodes + edges + ["```", "", "## Module inventory", "", "| Module | Lines | Classes | Functions | Imports |", "|---|---:|---:|---:|---:|"]
+    for item in records:
+        lines.append(f"| `{item['path']}` | {item['lines']} | {len(item['classes'])} | {len(item['functions'])} | {len(item['imports'])} |")
+    return "\n".join(lines) + "\n"
+
+
+def _git(args: list[str], root: Path) -> str:
+    try:
+        result = subprocess.run(["git", *args], cwd=root, text=True, capture_output=True, timeout=10, check=False)
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def changed_files(root: str | os.PathLike[str] = ".", base_ref: str = "HEAD^", head_ref: str = "HEAD") -> list[dict]:
+    base = Path(root).resolve()
+    output = _git(["diff", "--name-status", base_ref, head_ref, "--", "."], base)
+    result = []
+    for line in output.splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) != 2 or not _safe_path(Path(parts[1])):
+            continue
+        result.append({"status": parts[0], "path": parts[1]})
+    return sorted(result, key=lambda x: (x["path"], x["status"]))
+
+
+def report(records: list[dict], changes: list[dict] | None = None) -> dict:
+    return {
+        "version": 1,
+        "files": len(records),
+        "lines": sum(x["lines"] for x in records),
+        "classes": sum(len(x["classes"]) for x in records),
+        "functions": sum(len(x["functions"]) for x in records),
+        "imports": sum(len(x["imports"]) for x in records),
+        "changed": changes or [],
+    }
+
+
+def _redact(text: str) -> str:
+    return SECRET_RE.sub(lambda m: m.group(1) + "=<redacted>", text)
+
+
+def render(kind: str, root: str = ".", base_ref: str = "HEAD^") -> str:
+    records = analyze(root)
+    if kind == "api":
+        return api_markdown(records)
+    if kind == "architecture":
+        return architecture_markdown(records)
+    if kind == "changes":
+        return _redact(json.dumps(changed_files(root, base_ref), indent=2, sort_keys=True) + "\n")
+    if kind == "report":
+        return _redact(json.dumps(report(records, changed_files(root, base_ref)), indent=2, sort_keys=True) + "\n")
+    raise ValueError(f"unsupported documentation kind: {kind}")
+
+
+def write_generated(root: str = ".", base_ref: str = "HEAD^") -> list[Path]:
+    base = Path(root).resolve()
+    out = base / GENERATED_DIR
+    out.mkdir(parents=True, exist_ok=True)
+    outputs = {
+        "api": "api.md",
+        "architecture": "architecture.md",
+        "report": "report.json",
+        "changes": "changes.json",
+    }
+    written = []
+    for kind, filename in outputs.items():
+        path = out / filename
+        # Only files owned by this generator may be replaced.
+        content = render(kind, str(base), base_ref)
+        path.write_text(content, encoding="utf-8")
+        written.append(path)
+    return written

--- a/main.py
+++ b/main.py
@@ -17,9 +17,9 @@ from commands.fix import FixCommand
 from commands.refactor import RefactorCommand
 from commands.explain import ExplainCommand
 from commands.memory import MemoryCommand
-
 from commands.index import IndexCommand
 from commands.stats import StatsCommand
+from commands.docs import DocsCommand
 
 
 def main():
@@ -61,6 +61,21 @@ def main():
         IndexCommand().run()
     elif command == "stats":
         StatsCommand().run()
+    elif command == "docs":
+        action = args[0] if args and not args[0].startswith("-") else "all"
+        base_ref = "HEAD^"
+        output = None
+        if "--base" in args:
+            i = args.index("--base")
+            if i + 1 >= len(args):
+                raise SystemExit("Usage: docs [all|api|architecture|report|changes] [--base REF] [--output FILE]")
+            base_ref = args[i + 1]
+        if "--output" in args:
+            i = args.index("--output")
+            if i + 1 >= len(args):
+                raise SystemExit("Usage: docs [all|api|architecture|report|changes] [--base REF] [--output FILE]")
+            output = args[i + 1]
+        print(DocsCommand().run(action, base_ref=base_ref, output=output))
     else:
         print("Unknown command.")
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,52 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from core.documentation import analyze, architecture_markdown, api_markdown, report, render, source_files
+
+
+class DocumentationGeneratorTests(unittest.TestCase):
+    def make_project(self):
+        root = Path(tempfile.mkdtemp())
+        (root / "app.py").write_text(
+            '"""Example module."""\n\nimport json\n\nclass Greeter:\n    """Greets users."""\n    pass\n\ndef hello(name):\n    """Return a greeting."""\n    return name\n',
+            encoding="utf-8",
+        )
+        (root / ".env").write_text("API_KEY=should-not-be-read", encoding="utf-8")
+        return root
+
+    def test_source_analysis_is_structural(self):
+        root = self.make_project()
+        records = analyze(root)
+        self.assertEqual([r["path"] for r in records], ["app.py"])
+        self.assertEqual(records[0]["classes"][0]["name"], "Greeter")
+        self.assertEqual(records[0]["functions"][0]["name"], "hello")
+
+    def test_outputs_are_deterministic(self):
+        root = self.make_project()
+        records = analyze(root)
+        self.assertEqual(api_markdown(records), api_markdown(analyze(root)))
+        self.assertEqual(architecture_markdown(records), architecture_markdown(analyze(root)))
+        self.assertEqual(report(records), report(analyze(root)))
+
+    def test_report_is_json_and_excludes_runtime_state(self):
+        root = self.make_project()
+        payload = json.loads(render("report", str(root), "HEAD^"))
+        self.assertEqual(payload["files"], 1)
+        self.assertNotIn(".env", json.dumps(payload))
+
+    def test_secret_redaction_is_applied_to_change_output(self):
+        root = self.make_project()
+        # No git metadata means an empty, safe change report rather than arbitrary file content.
+        self.assertEqual(render("changes", str(root)), "[]\n")
+
+    def test_source_files_ignore_runtime_directories(self):
+        root = self.make_project()
+        (root / "build").mkdir()
+        (root / "build" / "runtime.py").write_text("password='secret'", encoding="utf-8")
+        self.assertEqual([p.name for p in source_files(root)], ["app.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #71

- Add deterministic AST-based API documentation generation without importing application code.
- Add source-derived architecture/module map and project metrics.
- Add bounded git change summaries using names/status only.
- Exclude runtime state, build artifacts, environment files, model registries, and .git data.
- Redact sensitive-looking values from generated text.
- Write only generator-owned files under docs/generated/.
- Add `docs` CLI command and README usage.
- Add focused unit coverage for determinism, filtering, JSON output, and safety.